### PR TITLE
Bootstrap Astra repo foundation and planning docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,19 @@
+---
+name: Epic
+about: Track a large body of work for Astra
+title: "[Epic] "
+labels: ["epic", "needs-triage"]
+assignees: []
+---
+
+## Outcome
+
+## Why this matters
+
+## Scope
+
+## Out of scope
+
+## Child issues
+
+## Exit criteria

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Propose a feature or improvement for Astra
+title: ""
+labels: ["needs-triage"]
+assignees: []
+---
+
+## Problem
+
+## Proposed solution
+
+## Alternatives considered
+
+## Acceptance criteria
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+## Why this change exists
+
+## Testing
+
+## Docs updated?
+- [ ] Yes
+- [ ] No
+
+## Checklist
+- [ ] Acceptance criteria satisfied
+- [ ] Tests added/updated where needed
+- [ ] Docs updated where needed
+- [ ] No obvious nonsense left behind

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # Astra
+
+Astra is an open-source data replication platform aiming to be the easy, fast alternative to Airbyte and the self-hostable answer to Fivetran.
+
+## Product goals
+
+- **Blazing fast pipelines** for database CDC and bulk replication
+- **Stupidly easy onboarding** through both UI flows and declarative YAML
+- **Easy self-hosting** with a sane Docker Compose path
+- **Cloud-ready architecture** without forcing cloud complexity onto local installs
+
+## v0.1 priorities
+
+Astra v0.1 focuses on one real vertical slice:
+- configure a source and destination
+- run an initial snapshot/backfill
+- continue with incremental sync/CDC where supported
+- view job history and status in the UI
+- manage the same config via YAML
+
+## Proposed architecture
+
+- Rust-first modular monolith for the control plane
+- Postgres for metadata/state/checkpoints
+- Object storage for durable staging/replay
+- High-performance DB CDC lane
+- Python runtime for long-tail SaaS/community connectors
+
+See the docs folder for the real details instead of README cosplay.
+
+## Docs
+
+- Product brief: `docs/product/brief.md`
+- Architecture RFC: `docs/architecture/rfc-0001-v1-architecture.md`
+- Kanban + epics + issue seed: `docs/product/kanban-and-issue-seed.md`
+- v0.1 roadmap: `docs/product/v0.1-roadmap.md`
+- ADR: `docs/decisions/adr-0001-modular-monolith.md`
+
+## Suggested repo layout
+
+```text
+apps/
+  control-plane/
+  web/
+  worker/
+  cli/
+crates/
+  astra-core/
+  astra-runtime/
+  astra-metadata/
+  astra-connectors/
+  astra-cdc/
+  astra-saas-sdk/
+  astra-python-runtime/
+  astra-yaml/
+  astra-api/
+  astra-observability/
+  astra-secrets/
+connectors/
+  rust/
+  python/
+docs/
+deploy/
+```
+
+## Immediate next steps
+
+1. Finalize the YAML spec and metadata model
+2. Build the control plane skeleton
+3. Implement the first Postgres CDC path
+4. Add object-storage staging and one destination loader
+5. Add UI onboarding and job history
+
+## Status
+
+Repo scaffold and planning docs have been initialized. The next real move is implementation, not more slideware.

--- a/docs/architecture/rfc-0001-v1-architecture.md
+++ b/docs/architecture/rfc-0001-v1-architecture.md
@@ -1,0 +1,122 @@
+# RFC-0001: Astra v1 Architecture
+
+## Status
+Proposed
+
+## Summary
+
+Astra v1 will be built as a **Rust-first modular monolith** with:
+- Postgres as metadata/state storage
+- object storage as durable staging/replay
+- a high-performance database CDC lane
+- a pragmatic Python runtime for long-tail SaaS/community connectors
+- UI and YAML sharing one canonical configuration model
+
+## Context
+
+Astra aims to be easier to install than Airbyte while being materially faster on CDC and bulk replication workloads. This requires avoiding orchestration-heavy designs and minimizing per-sync startup, serialization, and coordination overhead.
+
+## Decision
+
+### 1. Control plane
+Astra will start as a single primary service with clean internal boundaries:
+- API
+- scheduler
+- metadata/state manager
+- config validation
+- orchestration/runtime control
+- secrets abstraction
+- observability
+
+This is a modular monolith, not a bag of mud. Internal interfaces should make future extraction possible.
+
+### 2. Runtime lanes
+Astra will explicitly split runtime concerns into two major lanes.
+
+#### Lane A: Database CDC lane
+Optimized for:
+- Postgres
+- MySQL
+- later high-value relational sources
+
+Key capabilities:
+- log-based CDC
+- initial snapshot/backfill
+- incremental snapshot chunking
+- resumable checkpoints
+- partitioned parallelism
+- destination-native bulk load + merge/upsert
+
+#### Lane B: SaaS/API lane
+Optimized for:
+- incremental API syncs
+- rate-limited sources
+- long-tail connector breadth
+
+Key capabilities:
+- cursor/bookmark state
+- pagination/auth/rate-limit abstractions
+- per-stream failure isolation
+- easier connector authoring
+
+### 3. Connector model
+Astra will use a two-tier connector strategy.
+
+#### Tier A: Rust-native connectors
+Use for core/high-volume connectors where Astra’s performance reputation is made or lost.
+
+#### Tier B: Python runtime connectors
+Use for community and long-tail connectors. These run in bounded subprocesses instead of contaminating the hot path.
+
+### 4. Storage strategy
+#### Metadata/state
+- Postgres
+
+#### Durable staging/replay
+- S3 / GCS / R2 / MinIO compatible object storage
+
+Object storage is the default durability layer for replay, recovery, and decoupling capture from destination apply.
+
+### 5. Canonical configuration model
+Astra will define one canonical configuration/spec model.
+
+That model will be:
+- authored via YAML
+- validated via CLI/API
+- edited through the UI
+- versioned in metadata
+
+This prevents a split-brain product where the UI and declarative setup paths drift apart.
+
+### 6. Deployment model
+For v1, Astra must support:
+- Docker Compose self-hosting
+- single-node local development
+- future Kubernetes support without making Kubernetes a prerequisite
+
+## Consequences
+
+### Positive
+- simpler installation and operations
+- lower runtime overhead than Airbyte-like designs
+- clear differentiation around CDC performance and YAML-driven onboarding
+- future path toward remote workers without a rewrite
+
+### Negative
+- more discipline required inside the modular monolith
+- Rust-first core raises the bar for some contributors
+- Python subprocess model adds some runtime complexity for non-core connectors
+
+## Explicit anti-goals
+Astra v1 will not:
+- require Kafka/Redpanda/NATS as core infrastructure
+- optimize for dozens of connectors before the hot path is excellent
+- become a transformation engine competitor to dbt/Flink
+- split into many services before scale justifies it
+
+## Follow-up RFCs needed
+- YAML spec schema and versioning
+- metadata schema and state model
+- Postgres CDC lifecycle and checkpoint semantics
+- destination bulk loading contract
+- Python connector runtime manifest/protocol

--- a/docs/decisions/adr-0001-modular-monolith.md
+++ b/docs/decisions/adr-0001-modular-monolith.md
@@ -1,0 +1,32 @@
+# ADR-0001: Start as a Modular Monolith
+
+## Status
+Accepted
+
+## Decision
+Astra will begin as a modular monolith rather than a distributed microservice architecture.
+
+## Why
+- simpler local development
+- easier self-host installation
+- less orchestration overhead on the hot path
+- better fit for early-stage product iteration
+- materially lower operational burden than Airbyte-like designs
+
+## Guardrails
+This decision does **not** mean throwing everything into one undifferentiated binary.
+
+Astra must preserve internal boundaries for:
+- scheduler
+- runtime control
+- connector contracts
+- metadata/state storage
+- secrets
+- observability
+- worker transport
+
+## Revisit conditions
+We revisit this decision if:
+- remote worker pools become necessary for scale or network-topology reasons
+- multi-tenant cloud execution pressure requires stronger plane separation
+- connector isolation needs exceed subprocess boundaries

--- a/docs/product/brief.md
+++ b/docs/product/brief.md
@@ -1,0 +1,81 @@
+# Astra Product Brief
+
+## One-line pitch
+
+Astra is an open-source, high-performance data replication platform: the self-hostable alternative to Fivetran and a leaner, faster alternative to Airbyte.
+
+## Problem
+
+Current ELT/replication tools usually fail in one of two ways:
+
+1. **Managed-first tools** like Fivetran are convenient but expensive and closed.
+2. **Open-source tools** often become operationally heavy, connector-fragile, or slower than they should be.
+
+Teams want something that:
+- installs quickly
+- runs on-prem or in cloud
+- handles serious CDC and bulk sync workloads
+- is usable by both UI-first users and Git/YAML-driven teams
+
+## Product thesis
+
+Astra should win by being:
+- operationally lighter than Airbyte
+- easier to self-host than heavyweight orchestration stacks
+- faster on the hot path through a lean runtime and destination-native bulk loading
+- declarative enough for GitOps and enterprise onboarding
+
+## Target users
+
+### Primary
+- engineering teams moving data from OLTP systems into warehouses/lakes
+- startups and mid-market teams that want Fivetran-like convenience without Fivetran pricing/control limits
+- self-hosting/on-prem teams that cannot ship data through a SaaS-only control plane
+
+### Secondary
+- data platform teams that want a hackable replication core
+- open-source teams who want YAML-first deployment patterns
+
+## v0.1 goals
+
+Astra v0.1 must prove one serious vertical slice:
+- source configuration through UI and YAML
+- initial snapshot/backfill
+- continuous incremental sync/CDC for at least one database source
+- one production-relevant destination
+- job history, status, retries, and resume semantics
+- self-host install via Docker Compose
+
+## Non-goals for v0.1
+
+- dozens of connectors
+- full enterprise RBAC matrix
+- transformation engine that tries to replace dbt/Flink
+- complex stream-processing backbone as default install path
+- giant marketplace/plugin platform
+- multi-cluster managed cloud control plane
+
+## Early source/destination focus
+
+### Sources
+- Postgres CDC
+- MySQL CDC or one high-demand SaaS connector
+
+### Destinations
+- Snowflake or BigQuery
+- object storage staging as the durable replay layer
+
+## Differentiators
+
+1. **Fast CDC + bulk replication** instead of protocol-heavy generic syncs
+2. **YAML as a first-class source of truth**
+3. **UI and YAML sharing the same canonical model**
+4. **Simple self-host story** without distributed-systems cosplay
+5. **Hybrid connector strategy**: fast Rust core, pragmatic Python long tail
+
+## Success metrics for early versions
+
+- first install to successful sync in under 15 minutes
+- first meaningful Postgres -> warehouse sync substantially faster than an equivalent Airbyte setup
+- successful resume after interruption without manual cleanup
+- a contributor can author a simple SaaS connector without fighting the platform for days

--- a/docs/product/kanban-and-issue-seed.md
+++ b/docs/product/kanban-and-issue-seed.md
@@ -1,0 +1,102 @@
+# Astra Kanban, Epics, and Issue Seed
+
+## Kanban columns
+- Inbox
+- Ready
+- In Progress
+- Blocked
+- In Review
+- In QA
+- Done
+
+## Board rules
+- Nothing enters **In Progress** without acceptance criteria.
+- Anything blocked for more than 24 hours gets surfaced.
+- “Done” means merged, tested, docs updated where relevant, and deployed to preview/staging if applicable.
+- Keep WIP low. Half-finished work is just organized disappointment.
+
+## Recommended labels
+- arch
+- backend
+- cdc
+- connector
+- destination
+- ui
+- yaml
+- infra
+- docs
+- perf
+- v0.1
+- epic
+
+## Initial epics
+1. Repository foundation
+2. Metadata + control plane
+3. YAML spec + validation
+4. DB CDC runtime
+5. Destination loaders
+6. UI onboarding flow
+7. Python connector runtime
+8. Observability + ops
+9. v0.1 docs + release readiness
+
+## Initial issue seed
+
+### Repository foundation
+- Initialize Rust workspace and crate structure
+- Add formatting, linting, and CI workflows
+- Add Docker Compose for Postgres + MinIO + local services
+- Define environment/config loading strategy
+- Rewrite root README for actual onboarding
+- Add contribution guide and PR template
+
+### Metadata + control plane
+- Define metadata schema for sources, destinations, jobs, checkpoints, and run history
+- Build control-plane service skeleton
+- Add health, readiness, and version endpoints
+- Add job scheduler skeleton
+- Add secrets abstraction and local dev provider
+
+### YAML spec + validation
+- Define v1 YAML schema
+- Implement YAML parser and validator crate
+- Add CLI `validate` and `apply` commands
+- Store spec versions and renderable summaries in metadata
+
+### DB CDC runtime
+- Implement Postgres source connector skeleton
+- Support initial snapshot for selected tables
+- Add incremental snapshot chunking
+- Add WAL-based CDC tailing
+- Add checkpoint persistence and resume
+- Add partitioned loading pipeline
+
+### Destination loaders
+- Implement object-storage staging contract
+- Implement first warehouse destination loader
+- Support bulk load + merge/upsert path
+- Record sink commit markers and retry semantics
+
+### UI onboarding flow
+- Build sources/destinations/pipeline onboarding wizard
+- Add YAML preview/export from the UI
+- Add job history/status view
+- Add schema drift and error surfacing
+
+### Python connector runtime
+- Define connector manifest/protocol
+- Build subprocess launcher and resource limits
+- Ship one simple SaaS connector as proof
+
+### Observability + ops
+- Structured logging across services/crates
+- Metrics and tracing hooks
+- Failure classification and surfaced diagnostics
+- Local runbook and staging deployment path
+
+### Docs + release readiness
+- Product brief
+- Architecture RFCs
+- ADRs for stack decisions
+- Demo data/demo script
+- v0.1 release checklist

--- a/docs/product/v0.1-roadmap.md
+++ b/docs/product/v0.1-roadmap.md
@@ -1,0 +1,47 @@
+# Astra v0.1 Roadmap
+
+## Milestone 0 — Foundation
+- repo scaffold
+- docs baseline
+- CI baseline
+- Docker Compose baseline
+- local Postgres + MinIO bring-up
+
+Exit: another engineer can clone and boot the repo without ritual suffering.
+
+## Milestone 1 — Control plane skeleton
+- metadata schema
+- control-plane binary skeleton
+- CLI skeleton
+- health/readiness endpoints
+- scheduler skeleton
+- YAML validation plumbing
+
+Exit: Astra can accept a spec and persist a pipeline definition.
+
+## Milestone 2 — First real pipeline
+- Postgres snapshot
+- Postgres CDC tail
+- object-storage staging
+- first destination bulk loader
+- checkpoints + retries
+
+Exit: one real source-to-destination replication flow works end to end.
+
+## Milestone 3 — Usability and recovery
+- UI onboarding wizard
+- YAML import/export
+- run history + logs
+- retry/resume flows
+- schema drift warnings
+
+Exit: operators can set up and recover a pipeline without reading source code like a goblin.
+
+## Milestone 4 — Credibility pass
+- performance benchmarks
+- docs cleanup
+- one Python connector example
+- staging deploy
+- release checklist
+
+Exit: v0.1 looks like a real product, not a late-night manifesto.


### PR DESCRIPTION
## Summary
- bootstrap the initial Astra repo structure
- add product brief, architecture RFC, roadmap, and kanban/issue seed
- add GitHub issue/PR templates

## Why
Astra needs a concrete architecture and execution backbone before implementation starts drifting.

## Notes
- repo is intentionally scaffold-first and architecture-first
- follow-up issues/board were seeded separately
