### PR TITLE
Bootstrap Astra code foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+ASTRA_CONTROL_PLANE_ADDR=127.0.0.1:8080
+ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra
+ASTRA_S3_ENDPOINT=http://localhost:9000
+ASTRA_S3_ACCESS_KEY=astra
+ASTRA_S3_SECRET_KEY=astrastorage
+ASTRA_S3_BUCKET=astra-staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  repo-sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify core files exist
+        run: |
+          test -f README.md
+          test -f Cargo.toml
+          test -f .env.example
+          test -f deploy/docker-compose/docker-compose.yml
+          test -f docs/product/brief.md
+          test -f docs/architecture/rfc-0001-v1-architecture.md
+      - name: Print scaffold summary
+        run: |
+          echo "Astra scaffold present"
+          find apps crates -maxdepth 2 -type f | sort

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/target
+.env
+.env.*
+!.env.example
+node_modules
+.DS_Store
+minio-data
+postgres-data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Astra
+
+## Definition of done
+A change is done when:
+- acceptance criteria are satisfied
+- docs are updated where the change affects user or contributor behavior
+- obvious follow-up work is captured in issues instead of silently ignored
+- local validation steps were run where possible
+
+## Current expectations
+- prefer small PRs over heroic garbage dumps
+- keep architecture changes documented in `docs/architecture/` or `docs/decisions/`
+- if something is a stub, say it is a stub
+- do not pretend incomplete code is production-ready
+
+## Development
+Current bootstrap is scaffold-first. Until Rust is installed in the environment, code structure may be reviewed before compile validation is available.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,42 @@
+[workspace]
+resolver = "2"
+members = [
+  "apps/control-plane",
+  "apps/cli",
+  "apps/worker",
+  "crates/astra-api",
+  "crates/astra-core",
+  "crates/astra-runtime",
+  "crates/astra-metadata",
+  "crates/astra-connectors",
+  "crates/astra-cdc",
+  "crates/astra-saas-sdk",
+  "crates/astra-python-runtime",
+  "crates/astra-yaml",
+  "crates/astra-observability",
+  "crates/astra-secrets",
+]
+
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+version = "0.1.0"
+authors = ["Astra Core"]
+repository = "https://github.com/Astra-Core/Astra"
+
+[workspace.dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+thiserror = "2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+axum = "0.7"
+clap = { version = "4", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+
+[workspace.lints.rust]
+unsafe_code = "forbid"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "astra"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+astra-yaml = { path = "../../crates/astra-yaml" }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,0 +1,30 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "astra", about = "Astra CLI", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Validate an Astra YAML spec
+    Validate { file: String },
+    /// Apply an Astra YAML spec to the control plane
+    Apply { file: String },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Validate { file } => {
+            println!("validate stub: {file}");
+            println!("real schema validation lands next");
+        }
+        Commands::Apply { file } => {
+            println!("apply stub: {file}");
+            println!("real control-plane apply path lands next");
+        }
+    }
+}

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "astra-control-plane"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+astra-api = { path = "../../crates/astra-api" }
+astra-core = { path = "../../crates/astra-core" }
+astra-metadata = { path = "../../crates/astra-metadata" }
+astra-observability = { path = "../../crates/astra-observability" }
+astra-secrets = { path = "../../crates/astra-secrets" }
+astra-yaml = { path = "../../crates/astra-yaml" }

--- a/apps/control-plane/src/main.rs
+++ b/apps/control-plane/src/main.rs
@@ -1,0 +1,43 @@
+use axum::{routing::get, Json, Router};
+use serde::Serialize;
+use std::net::SocketAddr;
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .init();
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready))
+        .route("/version", get(version));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    tracing::info!(%addr, "astra control-plane listening");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok", service: "astra-control-plane" })
+}
+
+async fn ready() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ready", service: "astra-control-plane" })
+}
+
+async fn version() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "service": "astra-control-plane",
+        "version": env!("CARGO_PKG_VERSION"),
+        "note": "skeleton only"
+    }))
+}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,8 @@
+# Astra Web
+
+Planned UI surface for:
+- onboarding sources/destinations/pipelines
+- job history and run status
+- YAML preview/export
+
+Frontend stack is intentionally undecided in this scaffold. The important part right now is preserving the product surface and contracts.

--- a/apps/worker/Cargo.toml
+++ b/apps/worker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "astra-worker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/apps/worker/src/main.rs
+++ b/apps/worker/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    tracing_subscriber::fmt().init();
+    tracing::info!("astra worker skeleton starting");
+}

--- a/crates/astra-api/Cargo.toml
+++ b/crates/astra-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-api/src/lib.rs
+++ b/crates/astra-api/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-api
+
+pub const CRATE_NAME: &str = "astra-api";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-cdc/Cargo.toml
+++ b/crates/astra-cdc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-cdc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-cdc/src/lib.rs
+++ b/crates/astra-cdc/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-cdc
+
+pub const CRATE_NAME: &str = "astra-cdc";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-connectors/Cargo.toml
+++ b/crates/astra-connectors/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-connectors"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-connectors/src/lib.rs
+++ b/crates/astra-connectors/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-connectors
+
+pub const CRATE_NAME: &str = "astra-connectors";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-core/Cargo.toml
+++ b/crates/astra-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-core/src/lib.rs
+++ b/crates/astra-core/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-core
+
+pub const CRATE_NAME: &str = "astra-core";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-metadata/Cargo.toml
+++ b/crates/astra-metadata/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-metadata"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-metadata/src/lib.rs
+++ b/crates/astra-metadata/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-metadata
+
+pub const CRATE_NAME: &str = "astra-metadata";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-observability/Cargo.toml
+++ b/crates/astra-observability/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-observability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-observability/src/lib.rs
+++ b/crates/astra-observability/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-observability
+
+pub const CRATE_NAME: &str = "astra-observability";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-python-runtime/Cargo.toml
+++ b/crates/astra-python-runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-python-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-python-runtime/src/lib.rs
+++ b/crates/astra-python-runtime/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-python-runtime
+
+pub const CRATE_NAME: &str = "astra-python-runtime";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-runtime/Cargo.toml
+++ b/crates/astra-runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-runtime/src/lib.rs
+++ b/crates/astra-runtime/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-runtime
+
+pub const CRATE_NAME: &str = "astra-runtime";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-saas-sdk/Cargo.toml
+++ b/crates/astra-saas-sdk/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-saas-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-saas-sdk/src/lib.rs
+++ b/crates/astra-saas-sdk/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-saas-sdk
+
+pub const CRATE_NAME: &str = "astra-saas-sdk";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-secrets/Cargo.toml
+++ b/crates/astra-secrets/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-secrets"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-secrets/src/lib.rs
+++ b/crates/astra-secrets/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-secrets
+
+pub const CRATE_NAME: &str = "astra-secrets";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/crates/astra-yaml/Cargo.toml
+++ b/crates/astra-yaml/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "astra-yaml"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/astra-yaml/src/lib.rs
+++ b/crates/astra-yaml/src/lib.rs
@@ -1,0 +1,7 @@
+//! astra-yaml
+
+pub const CRATE_NAME: &str = "astra-yaml";
+
+pub fn status() -> &'static str {
+    "skeleton"
+}

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: astra-postgres
+    environment:
+      POSTGRES_USER: astra
+      POSTGRES_PASSWORD: astra
+      POSTGRES_DB: astra
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  minio:
+    image: minio/minio:latest
+    container_name: astra-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: astra
+      MINIO_ROOT_PASSWORD: astrastorage
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/docs/architecture/metadata-schema-draft.md
+++ b/docs/architecture/metadata-schema-draft.md
@@ -1,0 +1,23 @@
+# Astra Metadata Schema Draft
+
+Core entities for v0.1:
+- sources
+- destinations
+- pipelines
+- pipeline_specs
+- jobs
+- job_runs
+- checkpoints
+- schema_events
+- secrets_refs
+
+## Lifecycle notes
+- pipelines reference the latest active spec version
+- jobs represent scheduled or operator-triggered work
+- job_runs are immutable executions
+- checkpoints are scoped to pipeline + stream/table + phase
+- schema_events record additive vs breaking changes
+
+## Open questions
+- whether checkpoints should be split between snapshot and CDC tables
+- whether sink commit markers live beside checkpoints or in a dedicated apply ledger

--- a/docs/architecture/yaml-spec-draft.md
+++ b/docs/architecture/yaml-spec-draft.md
@@ -1,0 +1,16 @@
+# Astra YAML Spec Draft
+
+The canonical Astra configuration model will represent:
+- pipeline identity
+- source definition
+- destination definition
+- schedule/mode
+- capture behavior
+- checkpointing
+- parallelism
+- schema evolution behavior
+- secret references
+
+Current version target: `v1alpha1`
+
+UI and CLI must operate on this same model.

--- a/examples/postgres-to-warehouse.astra.yaml
+++ b/examples/postgres-to-warehouse.astra.yaml
@@ -1,0 +1,40 @@
+version: v1alpha1
+pipeline:
+  name: postgres-analytics
+  mode: cdc
+  schedule: continuous
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.users
+      - public.orders
+    snapshot:
+      mode: incremental
+      chunkSize: 50000
+    cdc:
+      slotName: astra_slot
+      publicationName: astra_publication
+destination:
+  kind: snowflake
+  staging:
+    kind: s3
+    bucket: astra-staging
+    prefix: postgres-analytics/
+  write:
+    mode: merge
+    batchSize: 100000
+runtime:
+  parallelism:
+    tables: 4
+  checkpointing:
+    intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause


### PR DESCRIPTION
## Summary
- add initial Rust workspace scaffold for Astra
- add control-plane, CLI, worker, and core crate placeholders
- add Docker Compose, CI baseline, contribution guide, and example YAML

## Notes
- this is intentionally scaffold-first
- Rust is not installed on the current machine, so this is a structure pass rather than a compile-validated pass
