### PR TITLE
OpenClaw: document local dev stack and example YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,32 @@ See the docs folder for the real details instead of README cosplay.
 
 - Product brief: `docs/product/brief.md`
 - Architecture RFC: `docs/architecture/rfc-0001-v1-architecture.md`
+- YAML spec draft: `docs/architecture/yaml-spec-draft.md`
+- Example pipeline config: `examples/postgres-to-warehouse.astra.yaml`
 - Kanban + epics + issue seed: `docs/product/kanban-and-issue-seed.md`
 - v0.1 roadmap: `docs/product/v0.1-roadmap.md`
 - ADR: `docs/decisions/adr-0001-modular-monolith.md`
+
+## Local development stack
+
+Astra includes a minimal local dependency stack at `deploy/docker-compose/docker-compose.yml`.
+
+Start it with:
+
+```bash
+docker compose -f deploy/docker-compose/docker-compose.yml up -d
+```
+
+Stop it with:
+
+```bash
+docker compose -f deploy/docker-compose/docker-compose.yml down
+```
+
+Default local ports:
+- Postgres metadata/state: `5432`
+- MinIO S3 API: `9000`
+- MinIO console: `9001`
 
 ## Suggested repo layout
 


### PR DESCRIPTION
## Summary
- add README links to the YAML spec draft and example pipeline config
- document local Docker Compose startup/shutdown for Postgres + MinIO
- document default local ports for the dependency stack

## Why
This closes the documentation gaps that were still blocking issue closure for:
- #12
- #22

## Acceptance criteria check
### #12 Add Docker Compose for Postgres and MinIO local development
- `deploy/docker-compose/docker-compose.yml` exists ✅
- Postgres service configured for local metadata/state ✅
- MinIO service configured for local object-storage staging ✅
- README documents startup commands and default ports ✅

### #22 Create example Postgres to warehouse YAML config
- example YAML file exists ✅
- source, destination, pipeline, and checkpointing concepts are visible ✅
- example matches the documented v1 spec draft ✅
- README/docs link to it ✅

## Validation
- `cargo test -q`
