### PR TITLE
OpenClaw: complete Astra web shell bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ deploy/
 4. Add object-storage staging and one destination loader
 5. Add UI onboarding and job history
 
+## Running the current web shell
+
+The temporary onboarding/job-status shell lives in `apps/web` and is served by the control-plane app.
+
+```bash
+cargo run -p astra-control-plane
+```
+
+Then open <http://127.0.0.1:8080>.
+
+The shell is intentionally lightweight and the React + TypeScript follow-up is tracked in issue #26.
+
 ## Status
 
 Repo scaffold and planning docs have been initialized. The next real move is implementation, not more slideware.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,8 +1,32 @@
-# Astra Web
+# Astra Web Shell
 
-Planned UI surface for:
-- onboarding sources/destinations/pipelines
-- job history and run status
-- YAML preview/export
+Temporary UI scaffold for Astra's product surface.
 
-Frontend stack is intentionally undecided in this scaffold. The important part right now is preserving the product surface and contracts.
+## What exists
+
+- onboarding shell view
+- job status shell view
+- YAML preview wired to the canonical example spec at `examples/postgres-to-warehouse.astra.yaml`
+- pipeline list wired to the control-plane API
+
+## Run it
+
+From the repo root:
+
+```bash
+cargo run -p astra-control-plane
+```
+
+Then open <http://127.0.0.1:8080>.
+
+If you only want to inspect the static files without the Rust backend, from `apps/web/` run:
+
+```bash
+python3 -m http.server 4173
+```
+
+That static mode is just for eyeballing markup/styles. The pipeline and YAML API calls will fail there unless you separately proxy the control-plane routes.
+
+## Why this is still a shell
+
+This is intentionally lightweight. The long-term UI direction is React + TypeScript, tracked in issue #26.

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -1,20 +1,41 @@
+const views = {
+  '/onboarding': document.getElementById('view-onboarding'),
+  '/job-status': document.getElementById('view-job-status'),
+  '/yaml': document.getElementById('view-yaml'),
+};
+
+function currentRoute() {
+  const hash = window.location.hash || '#/onboarding';
+  const route = hash.replace(/^#/, '');
+  return views[route] ? route : '/onboarding';
+}
+
+function renderRoute() {
+  const route = currentRoute();
+  Object.entries(views).forEach(([key, el]) => {
+    el.classList.toggle('hidden', key !== route);
+  });
+}
+
 async function loadPipelines() {
   const el = document.getElementById('pipelinesList');
   try {
     const res = await fetch('/api/v1/pipelines');
     const data = await res.json();
-    el.innerHTML = data.pipelines
-      .map(
-        (p) => `
-          <div class="pipeline-row">
-            <div>
-              <strong>${p.name}</strong>
-              <div class="muted">${p.source_kind} → ${p.destination_kind}</div>
-            </div>
-            <span class="badge">${p.status}</span>
-          </div>`
-      )
-      .join('');
+    el.innerHTML = data.pipelines.length
+      ? data.pipelines
+          .map(
+            (p) => `
+              <div class="pipeline-row">
+                <div>
+                  <strong>${p.name}</strong>
+                  <div class="muted">${p.source_kind} → ${p.destination_kind}</div>
+                </div>
+                <span class="badge">${p.status}</span>
+              </div>`
+          )
+          .join('')
+      : '<div class="muted">No pipelines yet. Apply a YAML spec to make this less empty.</div>';
   } catch (err) {
     el.textContent = 'Failed to load pipelines.';
   }
@@ -36,5 +57,8 @@ document.getElementById('refreshBtn').addEventListener('click', () => {
   loadYaml();
 });
 
+window.addEventListener('hashchange', renderRoute);
+
+renderRoute();
 loadPipelines();
 loadYaml();

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,10 +11,9 @@
       <aside class="sidebar">
         <div class="brand">Astra</div>
         <nav>
-          <a href="#pipelines">Pipelines</a>
-          <a href="#onboarding">Onboarding</a>
-          <a href="#runs">Runs</a>
-          <a href="#yaml">YAML</a>
+          <a href="#/onboarding">Onboarding</a>
+          <a href="#/job-status">Job status</a>
+          <a href="#/yaml">YAML</a>
         </nav>
       </aside>
       <main class="content">
@@ -26,34 +25,35 @@
           <button id="refreshBtn">Refresh</button>
         </header>
 
-        <section id="pipelines" class="card">
-          <h2>Pipelines</h2>
+        <section id="view-onboarding" class="card view">
+          <div class="grid">
+            <div>
+              <h2>Onboarding flow</h2>
+              <ol>
+                <li>Choose source</li>
+                <li>Choose destination</li>
+                <li>Review YAML</li>
+                <li>Validate</li>
+                <li>Apply</li>
+              </ol>
+            </div>
+            <div>
+              <h2>Canonical config model</h2>
+              <p>
+                The shell references Astra's YAML-first pipeline contract. The preview below is served from
+                <code>examples/postgres-to-warehouse.astra.yaml</code> so the UI stays anchored to the canonical config shape instead of inventing its own nonsense.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="view-job-status" class="card view hidden">
+          <h2>Job status</h2>
+          <p class="muted">Stubbed operator view for pipeline runs, retries, and current state.</p>
           <div id="pipelinesList">Loading pipelines…</div>
         </section>
 
-        <section id="onboarding" class="card grid">
-          <div>
-            <h2>Onboarding flow</h2>
-            <ol>
-              <li>Choose source</li>
-              <li>Choose destination</li>
-              <li>Review YAML</li>
-              <li>Validate</li>
-              <li>Apply</li>
-            </ol>
-          </div>
-          <div>
-            <h2>Upcoming UI surfaces</h2>
-            <ul>
-              <li>Source + destination forms</li>
-              <li>Pipeline status page</li>
-              <li>Schema drift notices</li>
-              <li>Job history and logs</li>
-            </ul>
-          </div>
-        </section>
-
-        <section id="yaml" class="card">
+        <section id="view-yaml" class="card view hidden">
           <h2>YAML preview</h2>
           <pre id="yamlPreview">Loading example spec…</pre>
         </section>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@astra/web-shell",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Temporary Astra web shell for onboarding and job status while the React + TypeScript app lands.",
+  "scripts": {
+    "dev": "cargo run -p astra-control-plane",
+    "static": "python3 -m http.server 4173"
+  }
+}

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -73,6 +73,14 @@ button {
   font-size: 12px;
 }
 .muted { color: #a9b5e9; }
+.hidden { display: none; }
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: #0d1430;
+  border: 1px solid #27345f;
+  border-radius: 8px;
+  padding: 2px 6px;
+}
 pre {
   white-space: pre-wrap;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- add `apps/web/package.json` for the current web shell
- add explicit shell views for onboarding, job status, and YAML preview
- document how to run the temporary shell
- keep the shell clearly positioned as temporary while React + TypeScript work continues in #26

## Why
Issue #19 required a real shell package, documented run instructions, and explicit shell views. The existing scaffold was close, but not cleanly over the line.

## Acceptance criteria check
- web app directory and package manifest exist ✅
- shell routes/views for onboarding and job status are stubbed ✅
- UI references the canonical YAML/config model where appropriate ✅
- run instructions are documented ✅
- follow-up work is created to migrate/expand the shell into a React + TypeScript app ✅ (#26)

## Validation
- `cargo test -q`
