### PR TITLE
OpenClaw: persist control-plane pipeline specs in Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -300,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +326,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -435,6 +448,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -452,6 +466,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "find-msvc-tools"
@@ -481,6 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -488,6 +509,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -502,6 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -519,13 +547,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -550,6 +590,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -715,6 +764,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +803,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -777,6 +854,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,10 +884,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -805,6 +942,48 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -836,9 +1015,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex-automata"
@@ -868,6 +1091,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -991,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,10 +1248,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1065,11 +1317,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -1088,6 +1356,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1187,10 +1494,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -1216,7 +1544,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -1241,6 +1569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1335,6 +1681,29 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -1491,6 +1860,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Astra is an open-source data replication platform aiming to be the easy, fast al
 
 - **Blazing fast pipelines** for database CDC and bulk replication
 - **Stupidly easy onboarding** through both UI flows and declarative YAML
-- **Easy self-hosting** with a sane Docker Compose path
+- **Easy self-hosting** with a sane Podman Compose path
 - **Cloud-ready architecture** without forcing cloud complexity onto local installs
 
 ## v0.1 priorities
@@ -45,13 +45,13 @@ Astra includes a minimal local dependency stack at `deploy/docker-compose/docker
 Start it with:
 
 ```bash
-docker compose -f deploy/docker-compose/docker-compose.yml up -d
+podman compose -f deploy/docker-compose/docker-compose.yml up -d
 ```
 
 Stop it with:
 
 ```bash
-docker compose -f deploy/docker-compose/docker-compose.yml down
+podman compose -f deploy/docker-compose/docker-compose.yml down
 ```
 
 Default local ports:
@@ -103,6 +103,8 @@ cargo run -p astra-control-plane
 ```
 
 Then open <http://127.0.0.1:8080>.
+
+If `ASTRA_DATABASE_URL` points at a reachable Postgres instance, the control plane now persists applied pipeline specs and pipeline summaries there. If not, it falls back to in-memory storage so local hacking still works instead of faceplanting.
 
 The shell is intentionally lightweight and the React + TypeScript follow-up is tracked in issue #26.
 

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -18,6 +18,7 @@ uuid.workspace = true
 thiserror.workspace = true
 async-trait = "0.1"
 sha2 = "0.10"
+tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 astra-api = { path = "../../crates/astra-api" }
 astra-core = { path = "../../crates/astra-core" }
 astra-metadata = { path = "../../crates/astra-metadata" }

--- a/apps/control-plane/src/config.rs
+++ b/apps/control-plane/src/config.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone)]
 pub struct ConfigModule {
     pub bind_addr: String,
+    pub database_url: Option<String>,
 }
 
 impl ConfigModule {
@@ -8,10 +9,21 @@ impl ConfigModule {
         Self {
             bind_addr: std::env::var("ASTRA_CONTROL_PLANE_ADDR")
                 .unwrap_or_else(|_| "127.0.0.1:8080".to_string()),
+            database_url: std::env::var("ASTRA_DATABASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
         }
     }
 
     pub const fn status(&self) -> &'static str {
-        "stubbed"
+        "configured"
+    }
+
+    pub fn database_backend_label(&self) -> &'static str {
+        if self.database_url.is_some() {
+            "postgres-or-fallback"
+        } else {
+            "memory"
+        }
     }
 }

--- a/apps/control-plane/src/main.rs
+++ b/apps/control-plane/src/main.rs
@@ -1,43 +1,25 @@
 mod api;
+mod app;
 mod config;
+mod error;
+mod http;
 mod metadata;
+mod models;
+mod repositories;
 mod scheduler;
+mod services;
+mod state;
 
 use api::ApiModule;
-use axum::{
-    response::{Html, IntoResponse},
-    routing::get,
-    Json, Router,
-};
 use config::ConfigModule;
 use metadata::MetadataModule;
+use repositories::{
+    memory::InMemoryPipelineRepository, postgres::PostgresPipelineRepository, PipelineRepository,
+};
 use scheduler::SchedulerModule;
-use serde::Serialize;
-use std::net::SocketAddr;
-
-const INDEX_HTML: &str = include_str!("../../web/index.html");
-const APP_JS: &str = include_str!("../../web/app.js");
-const STYLES_CSS: &str = include_str!("../../web/styles.css");
-const EXAMPLE_YAML: &str = include_str!("../../../examples/postgres-to-warehouse.astra.yaml");
-
-#[derive(Serialize)]
-struct HealthResponse {
-    status: &'static str,
-    service: &'static str,
-}
-
-#[derive(Serialize)]
-struct PipelineSummary {
-    name: &'static str,
-    source_kind: &'static str,
-    destination_kind: &'static str,
-    status: &'static str,
-}
-
-#[derive(Serialize)]
-struct PipelinesResponse {
-    pipelines: Vec<PipelineSummary>,
-}
+use services::PipelineService;
+use state::AppState;
+use std::{net::SocketAddr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -47,27 +29,19 @@ async fn main() -> anyhow::Result<()> {
     let api = ApiModule::new();
     let scheduler = SchedulerModule::new();
     let metadata = MetadataModule::new();
+    let repository = build_repository(&config).await;
+    let pipeline_service = Arc::new(PipelineService::new(repository));
+    let state = AppState::new(pipeline_service);
+    let app = app::build_router(state);
 
     tracing::info!(
         config = config.status(),
         api = api.status(),
         scheduler = scheduler.status(),
         metadata = metadata.status(),
+        database_backend = config.database_backend_label(),
         "astra control-plane modules initialized"
     );
-
-    let app = Router::new()
-        .route("/", get(index))
-        .route("/app.js", get(app_js))
-        .route("/styles.css", get(styles_css))
-        .route("/health", get(health))
-        .route("/ready", get(ready))
-        .route("/version", get(version))
-        .route("/api/v1/pipelines", get(pipelines))
-        .route(
-            "/api/v1/examples/postgres-to-warehouse",
-            get(example_postgres_to_warehouse),
-        );
 
     let addr: SocketAddr = config.bind_addr.parse()?;
     tracing::info!(%addr, "astra control-plane listening");
@@ -76,77 +50,23 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn index() -> Html<&'static str> {
-    Html(INDEX_HTML)
-}
-
-async fn app_js() -> impl IntoResponse {
-    (
-        [("content-type", "application/javascript; charset=utf-8")],
-        APP_JS,
-    )
-}
-
-async fn styles_css() -> impl IntoResponse {
-    ([("content-type", "text/css; charset=utf-8")], STYLES_CSS)
-}
-
-async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse {
-        status: "ok",
-        service: "astra-control-plane",
-    })
-}
-
-async fn ready() -> Json<serde_json::Value> {
-    Json(serde_json::json!({
-        "status": "ready",
-        "service": "astra-control-plane",
-        "modules": {
-            "config": "stubbed",
-            "api": "stubbed",
-            "scheduler": "stubbed",
-            "metadata": "stubbed"
+async fn build_repository(config: &ConfigModule) -> Arc<dyn PipelineRepository> {
+    if let Some(database_url) = config.database_url.as_deref() {
+        match PostgresPipelineRepository::connect(database_url).await {
+            Ok(repository) => {
+                tracing::info!("using Postgres pipeline repository");
+                return Arc::new(repository);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "failed to initialize Postgres repository, falling back to in-memory storage"
+                );
+            }
         }
-    }))
-}
+    } else {
+        tracing::info!("ASTRA_DATABASE_URL not set; using in-memory pipeline repository");
+    }
 
-async fn version() -> Json<serde_json::Value> {
-    Json(serde_json::json!({
-        "service": "astra-control-plane",
-        "version": env!("CARGO_PKG_VERSION"),
-        "note": "control-plane + module stubs",
-        "modules": {
-            "config": "stubbed",
-            "api": "stubbed",
-            "scheduler": "stubbed",
-            "metadata": "stubbed"
-        }
-    }))
-}
-
-async fn pipelines() -> Json<PipelinesResponse> {
-    Json(PipelinesResponse {
-        pipelines: vec![
-            PipelineSummary {
-                name: "postgres-analytics",
-                source_kind: "postgres",
-                destination_kind: "snowflake",
-                status: "draft",
-            },
-            PipelineSummary {
-                name: "billing-replication",
-                source_kind: "mysql",
-                destination_kind: "bigquery",
-                status: "planned",
-            },
-        ],
-    })
-}
-
-async fn example_postgres_to_warehouse() -> impl IntoResponse {
-    (
-        [("content-type", "text/plain; charset=utf-8")],
-        EXAMPLE_YAML,
-    )
+    Arc::new(InMemoryPipelineRepository::default())
 }

--- a/apps/control-plane/src/repositories/mod.rs
+++ b/apps/control-plane/src/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub mod memory;
 pub mod pipeline_repository;
+pub mod postgres;
 
 pub use pipeline_repository::{AppliedPipelineRecord, PipelineRecord, PipelineRepository};

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -1,0 +1,249 @@
+use crate::repositories::{AppliedPipelineRecord, PipelineRecord, PipelineRepository};
+use anyhow::Context;
+use async_trait::async_trait;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_postgres::{types::Json, Client, NoTls};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct PostgresPipelineRepository {
+    client: Arc<Mutex<Client>>,
+}
+
+impl PostgresPipelineRepository {
+    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
+        let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+            .await
+            .with_context(|| {
+                format!("failed to connect to Postgres using ASTRA_DATABASE_URL: {database_url}")
+            })?;
+
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                tracing::error!(?error, "postgres connection task exited");
+            }
+        });
+
+        let repository = Self {
+            client: Arc::new(Mutex::new(client)),
+        };
+        repository.ensure_schema().await?;
+        Ok(repository)
+    }
+
+    async fn ensure_schema(&self) -> anyhow::Result<()> {
+        self.client
+            .lock()
+            .await
+            .batch_execute(
+                r#"
+                CREATE TABLE IF NOT EXISTS pipelines (
+                    id UUID PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    source_kind TEXT NOT NULL,
+                    destination_kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    active_spec_id UUID,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+
+                CREATE TABLE IF NOT EXISTS pipeline_specs (
+                    id UUID PRIMARY KEY,
+                    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+                    version INTEGER NOT NULL,
+                    spec_version TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    spec_yaml TEXT NOT NULL,
+                    spec_json JSONB NOT NULL,
+                    created_by TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE (pipeline_id, version),
+                    UNIQUE (pipeline_id, content_hash)
+                );
+                "#,
+            )
+            .await
+            .context("failed to bootstrap pipeline persistence schema")?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PipelineRepository for PostgresPipelineRepository {
+    async fn list_pipelines(&self) -> anyhow::Result<Vec<PipelineRecord>> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT p.name, p.source_kind, p.destination_kind, p.status, COALESCE(ps.version, 0) AS spec_version
+                FROM pipelines p
+                LEFT JOIN pipeline_specs ps ON ps.id = p.active_spec_id
+                ORDER BY p.name ASC
+                "#,
+                &[],
+            )
+            .await
+            .context("failed to list pipelines from Postgres")?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| PipelineRecord {
+                name: row.get("name"),
+                source_kind: row.get("source_kind"),
+                destination_kind: row.get("destination_kind"),
+                status: row.get("status"),
+                spec_version: row.get("spec_version"),
+            })
+            .collect())
+    }
+
+    async fn apply_spec(
+        &self,
+        spec: astra_yaml::AstraSpec,
+        raw_yaml: String,
+        created_by: Option<String>,
+    ) -> anyhow::Result<AppliedPipelineRecord> {
+        let pipeline_name = spec.pipeline.name.clone();
+        let source_kind = spec.source.kind.clone();
+        let destination_kind = spec.destination.kind.clone();
+        let status = "active".to_string();
+        let spec_version_label = spec.version.clone();
+        let spec_model: Value =
+            serde_json::to_value(&spec).context("failed to serialize normalized spec JSON")?;
+        let content_hash = hash_content(&raw_yaml);
+
+        let mut client = self.client.lock().await;
+        let transaction = client
+            .transaction()
+            .await
+            .context("failed to start Postgres transaction")?;
+
+        let existing = transaction
+            .query_opt(
+                r#"
+                SELECT p.id, COALESCE(ps.version, 0) AS active_version, ps.content_hash
+                FROM pipelines p
+                LEFT JOIN pipeline_specs ps ON ps.id = p.active_spec_id
+                WHERE p.name = $1
+                "#,
+                &[&pipeline_name],
+            )
+            .await
+            .context("failed to load existing pipeline row")?;
+
+        let (pipeline_id, next_version) = if let Some(row) = existing {
+            let pipeline_id: Uuid = row.get("id");
+            let active_version: i32 = row.get("active_version");
+            let active_hash: Option<String> = row.get("content_hash");
+
+            if active_hash.as_deref() == Some(content_hash.as_str()) {
+                transaction
+                    .commit()
+                    .await
+                    .context("failed to commit no-op Postgres apply")?;
+                return Ok(AppliedPipelineRecord {
+                    pipeline: PipelineRecord {
+                        name: pipeline_name,
+                        source_kind,
+                        destination_kind,
+                        status,
+                        spec_version: active_version,
+                    },
+                    content_hash,
+                });
+            }
+
+            (pipeline_id, active_version + 1)
+        } else {
+            let pipeline_id = Uuid::new_v4();
+            transaction
+                .execute(
+                    r#"
+                    INSERT INTO pipelines (id, name, source_kind, destination_kind, status)
+                    VALUES ($1, $2, $3, $4, $5)
+                    "#,
+                    &[
+                        &pipeline_id,
+                        &pipeline_name,
+                        &source_kind,
+                        &destination_kind,
+                        &status,
+                    ],
+                )
+                .await
+                .context("failed to insert pipeline row")?;
+            (pipeline_id, 1)
+        };
+
+        let spec_id = Uuid::new_v4();
+        transaction
+            .execute(
+                r#"
+                INSERT INTO pipeline_specs (id, pipeline_id, version, spec_version, content_hash, spec_yaml, spec_json, created_by)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                "#,
+                &[
+                    &spec_id,
+                    &pipeline_id,
+                    &next_version,
+                    &spec_version_label,
+                    &content_hash,
+                    &raw_yaml,
+                    &Json(&spec_model),
+                    &created_by,
+                ],
+            )
+            .await
+            .context("failed to insert pipeline spec row")?;
+
+        transaction
+            .execute(
+                r#"
+                UPDATE pipelines
+                SET source_kind = $2,
+                    destination_kind = $3,
+                    status = $4,
+                    active_spec_id = $5,
+                    updated_at = NOW()
+                WHERE id = $1
+                "#,
+                &[
+                    &pipeline_id,
+                    &source_kind,
+                    &destination_kind,
+                    &status,
+                    &spec_id,
+                ],
+            )
+            .await
+            .context("failed to update pipeline row")?;
+
+        transaction
+            .commit()
+            .await
+            .context("failed to commit Postgres apply")?;
+
+        Ok(AppliedPipelineRecord {
+            pipeline: PipelineRecord {
+                name: pipeline_name,
+                source_kind,
+                destination_kind,
+                status,
+                spec_version: next_version,
+            },
+            content_hash,
+        })
+    }
+}
+
+fn hash_content(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -39,7 +39,7 @@ impl PipelineService {
             pipeline_name: applied.pipeline.name,
             spec_version: applied.pipeline.spec_version,
             content_hash: applied.content_hash,
-            message: "pipeline spec applied in memory".to_string(),
+            message: "pipeline spec applied".to_string(),
         })
     }
 }


### PR DESCRIPTION
## Summary
- wire the control-plane binary into the real modular app/router/state/service flow
- add Postgres-backed pipeline/spec persistence for apply + list
- bootstrap minimal schema for `pipelines` and `pipeline_specs`
- keep pragmatic in-memory fallback for local/dev cases where `ASTRA_DATABASE_URL` is not set or Postgres is unavailable
- update docs to use Podman wording for local container flows

## Why
Astra had repository/service structure for apply/list, but the running binary was still serving stubbed behavior directly. This PR makes the control plane actually use durable persistence for the first real vertical slice.

## Scope
This intentionally covers only the current control-plane surfaces:
- `GET /api/v1/pipelines`
- `POST /api/v1/specs/apply`

It does not try to solve jobs, checkpoints, schema drift, or historical spec browsing yet.

## Validation
- `cargo fmt`
- `cargo check -p astra-control-plane`
- `cargo test -p astra-control-plane -p astra-yaml`
- real Podman-backed Postgres smoke test:
  - start Postgres with Podman
  - boot control plane with `ASTRA_DATABASE_URL`
  - verify initial empty pipeline list
  - apply `examples/postgres-to-warehouse.astra.yaml`
  - verify pipeline list shows persisted result
  - re-apply identical YAML and confirm `spec_version` remains `1`

## Notes
- schema bootstrapping is inline SQL for now; migrations can follow in a later PR
- in-memory fallback remains for developer convenience, but Postgres is now the real persistence path when configured
