### PR TITLE
OpenClaw: wire Postgres snapshot into local staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,33 @@ deploy/
 4. Add object-storage staging and one destination loader
 5. Add UI onboarding and job history
 
-## Running the current web shell
+## Running the current web app foundation
 
-The temporary onboarding/job-status shell lives in `apps/web` and is served by the control-plane app.
+The React + TypeScript web app foundation lives in `apps/web`.
+
+For backend-only work, run the control plane from the repo root:
 
 ```bash
 cargo run -p astra-control-plane
 ```
 
-Then open <http://127.0.0.1:8080>.
+For frontend development, run the control plane in one terminal, then in `apps/web/` run:
+
+```bash
+npm install
+npm run dev
+```
+
+Open <http://127.0.0.1:4173> for the Vite dev server.
+
+For a self-hosted frontend build served by the Rust control plane, in `apps/web/` run:
+
+```bash
+npm install
+npm run build
+```
+
+Then open <http://127.0.0.1:8080> after starting `cargo run -p astra-control-plane`.
 
 If `ASTRA_DATABASE_URL` points at a reachable Postgres instance, the control plane now persists applied pipeline specs and pipeline summaries there. If not, it falls back to in-memory storage so local hacking still works instead of faceplanting.
 
@@ -117,6 +135,16 @@ cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
 ```
 
 That currently does the minimum useful thing: parse and validate the Postgres source config, inspect table schemas from a reachable Postgres instance, and emit a snapshot-oriented SQL plan for the captured tables.
+
+There is also a first honest execution slice for local/self-hosted development:
+
+```bash
+export POSTGRES_PASSWORD=...
+export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
+cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
+```
+
+That flow reuses the Postgres connector for discovery plus snapshot reads, converts rows to JSONL.gz in-process, and writes one staged chunk per captured table via the filesystem-backed staging adapter. It's intentionally narrow: no sink apply yet, no resume/checkpoint loop yet, and no fake cloud dependencies.
 
 The shell is intentionally lightweight and the React + TypeScript follow-up is tracked in issue #26.
 

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -11,3 +11,4 @@ clap.workspace = true
 tokio.workspace = true
 astra-yaml = { path = "../../crates/astra-yaml" }
 astra-connectors = { path = "../../crates/astra-connectors" }
+astra-runtime = { path = "../../crates/astra-runtime" }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,6 +1,12 @@
-use astra_connectors::{PostgresDiscoverOptions, PostgresSource};
+use anyhow::{bail, Context};
+use astra_connectors::{PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions};
+use astra_runtime::{
+    LocalStageChunkStore, LocalStagingConfig, StageChunkRequest, StageChunkStore, StagingConfig,
+    StagingKind,
+};
 use astra_yaml::AstraSpec;
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "astra", about = "Astra CLI", version)]
@@ -17,6 +23,14 @@ enum Commands {
     Apply { file: String },
     /// Discover schema details for a Postgres source using a local/self-hosted database
     DiscoverSource { file: String },
+    /// Execute a minimal local Postgres snapshot and write staged chunks to the filesystem adapter
+    SnapshotToLocalStaging {
+        file: String,
+        #[arg(long)]
+        max_rows_per_table: Option<u64>,
+        #[arg(long)]
+        staging_root: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -26,6 +40,11 @@ async fn main() -> anyhow::Result<()> {
         Commands::Validate { file } => validate(&file)?,
         Commands::Apply { file } => apply(&file)?,
         Commands::DiscoverSource { file } => discover_source(&file).await?,
+        Commands::SnapshotToLocalStaging {
+            file,
+            max_rows_per_table,
+            staging_root,
+        } => snapshot_to_local_staging(&file, max_rows_per_table, staging_root).await?,
     }
     Ok(())
 }
@@ -94,4 +113,84 @@ async fn discover_source(file: &str) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+async fn snapshot_to_local_staging(
+    file: &str,
+    max_rows_per_table: Option<u64>,
+    staging_root: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+
+    if spec.source.kind != "postgres" {
+        bail!("snapshot-to-local-staging currently supports source.kind=postgres only");
+    }
+
+    let staging = spec
+        .destination
+        .staging
+        .as_ref()
+        .context("destination.staging is required for local snapshot staging")?;
+    let source = PostgresSource::from_spec(&spec)?;
+    let discovery = source
+        .discover(PostgresDiscoverOptions { tables: vec![] })
+        .await?;
+    let snapshot = source
+        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
+            tables: vec![],
+            max_rows_per_table,
+        })
+        .await?;
+
+    let root_dir = staging_root
+        .or_else(default_staging_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/staging"));
+    let store = LocalStageChunkStore::new(LocalStagingConfig {
+        root_dir: root_dir.clone(),
+        storage: StagingConfig {
+            kind: StagingKind::Local,
+            bucket: staging.bucket.clone(),
+            prefix: staging.prefix.clone().unwrap_or_default(),
+        },
+    });
+
+    store.ensure_ready()?;
+
+    println!("discovered postgres source: {}", spec.pipeline.name);
+    println!("catalog tables: {}", discovery.catalog.tables.len());
+    println!("local staging root: {}", root_dir.display());
+    println!("staged chunks:");
+
+    for table in snapshot.tables {
+        let chunk = store.write_chunk(StageChunkRequest {
+            pipeline_name: spec.pipeline.name.clone(),
+            stream_name: table.table.clone(),
+            partition_key: "default".to_string(),
+            sequence: table.sequence,
+            payload: astra_runtime::StageChunkPayload::jsonl_gzip(
+                table.row_count,
+                table.rows_jsonl_gzip,
+            ),
+        })?;
+
+        let resolved = store.resolve_path(&chunk.object_key);
+        println!(
+            "- {} -> {} rows -> {}",
+            table.table,
+            chunk.row_count,
+            resolved.display()
+        );
+        println!("  sql: {}", table.sql);
+        println!(
+            "  chunk: bucket={} key={} bytes={}",
+            chunk.bucket, chunk.object_key, chunk.bytes_written
+        );
+    }
+
+    Ok(())
+}
+
+fn default_staging_root_from_env() -> Option<PathBuf> {
+    std::env::var_os("ASTRA_STAGING_LOCAL_ROOT").map(PathBuf::from)
 }

--- a/crates/astra-connectors/Cargo.toml
+++ b/crates/astra-connectors/Cargo.toml
@@ -15,5 +15,6 @@ serde_yaml.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+flate2 = "1"
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 astra-yaml = { path = "../astra-yaml" }

--- a/crates/astra-connectors/src/lib.rs
+++ b/crates/astra-connectors/src/lib.rs
@@ -3,7 +3,8 @@ pub mod postgres;
 pub use postgres::{
     ColumnSchema, DiscoverReport, PostgresCdcSettings, PostgresConnectionConfig,
     PostgresDiscoverOptions, PostgresSnapshotPlan, PostgresSource, PostgresSourceConfig,
-    SourceCatalog, SourceTable,
+    SnapshotExecutionOptions, SnapshotExecutionReport, SnapshotTableChunk, SourceCatalog,
+    SourceTable,
 };
 
 pub const CRATE_NAME: &str = "astra-connectors";

--- a/crates/astra-connectors/src/postgres.rs
+++ b/crates/astra-connectors/src/postgres.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use tokio_postgres::{Client, NoTls};
+use tokio_postgres::{types::Type, Client, NoTls};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PostgresConnectionConfig {
@@ -84,6 +84,29 @@ pub struct DiscoverReport {
     pub snapshot_plan: PostgresSnapshotPlan,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotExecutionOptions {
+    #[serde(default)]
+    pub tables: Vec<String>,
+    #[serde(default)]
+    pub max_rows_per_table: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotTableChunk {
+    pub table: String,
+    pub sql: String,
+    pub row_count: u64,
+    pub sequence: u64,
+    pub rows_jsonl_gzip: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotExecutionReport {
+    pub source_kind: String,
+    pub tables: Vec<SnapshotTableChunk>,
+}
+
 pub struct PostgresSource {
     config: PostgresSourceConfig,
 }
@@ -164,6 +187,52 @@ impl PostgresSource {
                 tables,
             },
             snapshot_plan: self.snapshot_plan(),
+        })
+    }
+
+    pub async fn snapshot_to_jsonl_gzip(
+        &self,
+        options: SnapshotExecutionOptions,
+    ) -> anyhow::Result<SnapshotExecutionReport> {
+        let target_tables = if options.tables.is_empty() {
+            self.config.tables.clone()
+        } else {
+            normalize_tables(&options.tables)?
+        };
+
+        let client = connect(&self.config.connection).await?;
+        let mut tables = Vec::new();
+
+        for table_name in target_tables {
+            let sql = build_snapshot_json_sql(&table_name, options.max_rows_per_table)?;
+            let rows = client
+                .query(&sql, &[])
+                .await
+                .with_context(|| format!("failed to snapshot table {table_name}"))?;
+
+            let mut jsonl = Vec::new();
+            let mut row_count = 0_u64;
+            for row in rows {
+                let value: serde_json::Value = read_json_value(&row, "record")?;
+                serde_json::to_writer(&mut jsonl, &value)
+                    .with_context(|| format!("failed to encode staged row for {table_name}"))?;
+                jsonl.push(b'\n');
+                row_count += 1;
+            }
+
+            let rows_jsonl_gzip = gzip_bytes(&jsonl)?;
+            tables.push(SnapshotTableChunk {
+                table: table_name,
+                sql,
+                row_count,
+                sequence: 0,
+                rows_jsonl_gzip,
+            });
+        }
+
+        Ok(SnapshotExecutionReport {
+            source_kind: "postgres".to_string(),
+            tables,
         })
     }
 }
@@ -374,9 +443,47 @@ fn quote_qualified_table(table_name: &str) -> String {
     )
 }
 
+fn build_snapshot_json_sql(table_name: &str, max_rows: Option<u64>) -> anyhow::Result<String> {
+    let table = quote_qualified_table(table_name);
+    let mut sql = format!(
+        "SELECT to_jsonb(snapshot_row) AS record FROM (SELECT * FROM {table}) AS snapshot_row"
+    );
+    if let Some(limit) = max_rows {
+        sql.push_str(&format!(" LIMIT {limit}"));
+    }
+    Ok(sql)
+}
+
+fn read_json_value(row: &tokio_postgres::Row, column: &str) -> anyhow::Result<serde_json::Value> {
+    let idx = row
+        .columns()
+        .iter()
+        .position(|candidate| candidate.name() == column)
+        .ok_or_else(|| anyhow!("column {column} was not returned from snapshot query"))?;
+
+    match *row.columns()[idx].type_() {
+        Type::JSON | Type::JSONB => Ok(row.get(idx)),
+        _ => bail!("snapshot query column {column} was not json/jsonb"),
+    }
+}
+
+fn gzip_bytes(input: &[u8]) -> anyhow::Result<Vec<u8>> {
+    use std::io::Write;
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder
+        .write_all(input)
+        .context("failed to gzip snapshot rows for staging")?;
+    encoder
+        .finish()
+        .context("failed to finalize gzipped snapshot rows")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::read::GzDecoder;
+    use std::io::Read;
 
     #[test]
     fn builds_source_from_example_spec() {
@@ -407,6 +514,24 @@ mod tests {
         assert_eq!(plan.tables[0].sql, "SELECT * FROM \"public\".\"orders\"");
         assert_eq!(plan.tables[0].chunk_size, Some(50000));
         assert_eq!(plan.tables[0].mode, "incremental");
+    }
+
+    #[test]
+    fn snapshot_json_sql_wraps_rows_as_json() {
+        assert_eq!(
+            build_snapshot_json_sql("public.orders", Some(25)).expect("sql builds"),
+            "SELECT to_jsonb(snapshot_row) AS record FROM (SELECT * FROM \"public\".\"orders\") AS snapshot_row LIMIT 25"
+        );
+    }
+
+    #[test]
+    fn gzip_helper_round_trips() {
+        let encoded = gzip_bytes(b"{\"id\":1}\n{\"id\":2}\n").expect("gzip works");
+        let mut decoded = String::new();
+        GzDecoder::new(encoded.as_slice())
+            .read_to_string(&mut decoded)
+            .expect("gzip decodes");
+        assert_eq!(decoded, "{\"id\":1}\n{\"id\":2}\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wire the Postgres source connector skeleton into the local staging path
- add a minimal snapshot execution flow that discovers tables, builds SQL, reads rows, and writes JSONL.gz chunk files via the existing local staging adapter
- add CLI entrypoint: `astra snapshot-to-local-staging <spec>`

## Why
Astra had discovery/planning and a local staging adapter, but not the actual bridge between them. This PR creates the first honest local snapshot-to-staging slice without pretending sink apply or CDC already exist.

## Validation
- `cargo fmt`
- `cargo test -p astra-connectors -p astra-runtime -p astra -- --nocapture`
- real Podman-backed smoke test:
  - start local Postgres with Podman
  - seed sample `users` and `orders` tables
  - run `cargo run -p astra -- snapshot-to-local-staging <spec>`
  - verify two `.jsonl.gz` staged chunk files are written
  - verify staged rows contain expected sample data

## Notes
- local/self-hosted only
- one chunk per table for now
- no destination apply, checkpoint loop, or CDC yet
