### PR TITLE
OpenClaw: add local Postgres raw destination loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ name = "astra-connectors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "astra-runtime",
  "astra-yaml",
  "flate2",
  "serde",

--- a/README.md
+++ b/README.md
@@ -144,7 +144,19 @@ export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
 cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
 ```
 
-That flow reuses the Postgres connector for discovery plus snapshot reads, converts rows to JSONL.gz in-process, and writes one staged chunk per captured table via the filesystem-backed staging adapter. It's intentionally narrow: no sink apply yet, no resume/checkpoint loop yet, and no fake cloud dependencies.
+That flow reuses the Postgres connector for discovery plus snapshot reads, converts rows to JSONL.gz in-process, and writes one staged chunk per captured table via the filesystem-backed staging adapter.
+
+There is now a matching narrow-but-real destination leg for local/self-hosted Postgres raw loading:
+
+```bash
+export POSTGRES_PASSWORD=...
+export WAREHOUSE_PASSWORD=...
+export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
+cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-postgres-raw.astra.yaml --max-rows-per-table 1000
+cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml
+```
+
+The loader reads staged `JSONL.gz` chunks and lands them in raw Postgres tables (default schema `astra_raw`) with one `jsonb` payload column plus loader metadata. It also records applied chunk object keys so reruns skip already-loaded chunks instead of duplicating them like idiots.
 
 If you want the same flow against a local MinIO bucket instead of the filesystem, bring up the Podman Compose stack and run:
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::{bail, Context};
-use astra_connectors::{PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions};
+use astra_connectors::{
+    PostgresDestinationLoader, PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions,
+};
 use astra_runtime::{
     LocalStageChunkStore, LocalStagingConfig, MinioStageChunkStore, MinioStagingConfig,
     StageChunkPayload, StageChunkRequest, StageChunkStore, StagingConfig, StagingKind,
@@ -45,6 +47,12 @@ enum Commands {
         #[arg(long)]
         secret_key: Option<String>,
     },
+    /// Load locally staged JSONL.gz chunks into raw Postgres destination tables
+    LoadLocalStagingToPostgres {
+        file: String,
+        #[arg(long)]
+        staging_root: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -76,6 +84,9 @@ async fn main() -> anyhow::Result<()> {
                 secret_key,
             )
             .await?
+        }
+        Commands::LoadLocalStagingToPostgres { file, staging_root } => {
+            load_local_staging_to_postgres(&file, staging_root).await?
         }
     }
     Ok(())
@@ -313,6 +324,75 @@ fn staging_from_spec(spec: &AstraSpec) -> anyhow::Result<ResolvedStaging> {
         bucket: staging.bucket.clone(),
         prefix: staging.prefix.clone().unwrap_or_default(),
     })
+}
+
+async fn load_local_staging_to_postgres(
+    file: &str,
+    staging_root: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+
+    let staging = spec
+        .destination
+        .staging
+        .as_ref()
+        .context("destination.staging is required for local destination loading")?;
+    let loader = PostgresDestinationLoader::from_spec(&spec)?;
+    let root_dir = staging_root
+        .or_else(default_staging_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/staging"));
+    let store = LocalStageChunkStore::new(LocalStagingConfig {
+        root_dir: root_dir.clone(),
+        storage: StagingConfig {
+            kind: StagingKind::Local,
+            bucket: staging.bucket.clone(),
+            prefix: staging.prefix.clone().unwrap_or_default(),
+        },
+    });
+
+    let staged_chunks = store.list_chunks_for_pipeline(&spec.pipeline.name)?;
+    if staged_chunks.is_empty() {
+        bail!(
+            "no staged chunks found for pipeline {} under {}",
+            spec.pipeline.name,
+            root_dir.display()
+        );
+    }
+
+    let mut chunk_payloads = Vec::new();
+    for mut chunk in staged_chunks {
+        let bytes = store.read_chunk(&chunk).await?;
+        chunk.bytes_written = bytes.len() as u64;
+        chunk_payloads.push((chunk, bytes));
+    }
+
+    let report = loader.load_local_stage_chunks(chunk_payloads).await?;
+    println!(
+        "loaded staged chunks into postgres raw schema: {}",
+        report.schema
+    );
+    println!(
+        "destination host: {}:{}",
+        loader.config().host,
+        loader.config().port
+    );
+    println!("local staging root: {}", root_dir.display());
+    for chunk in report.applied_chunks {
+        println!(
+            "- {} -> {} ({})",
+            chunk.object_key,
+            chunk.table_name,
+            if chunk.skipped {
+                "already applied"
+            } else {
+                "applied"
+            }
+        );
+        println!("  rows written: {}", chunk.rows_written);
+    }
+
+    Ok(())
 }
 
 fn default_staging_root_from_env() -> Option<PathBuf> {

--- a/crates/astra-connectors/Cargo.toml
+++ b/crates/astra-connectors/Cargo.toml
@@ -18,3 +18,4 @@ tokio.workspace = true
 flate2 = "1"
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 astra-yaml = { path = "../astra-yaml" }
+astra-runtime = { path = "../astra-runtime" }

--- a/crates/astra-connectors/src/lib.rs
+++ b/crates/astra-connectors/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod postgres;
+pub mod postgres_destination;
 
 pub use postgres::{
     ColumnSchema, DiscoverReport, PostgresCdcSettings, PostgresConnectionConfig,
     PostgresDiscoverOptions, PostgresSnapshotPlan, PostgresSource, PostgresSourceConfig,
     SnapshotExecutionOptions, SnapshotExecutionReport, SnapshotTableChunk, SourceCatalog,
     SourceTable,
+};
+pub use postgres_destination::{
+    PostgresDestinationConfig, PostgresDestinationLoader, RawLoadChunkResult, RawLoadReport,
 };
 
 pub const CRATE_NAME: &str = "astra-connectors";

--- a/crates/astra-connectors/src/postgres_destination.rs
+++ b/crates/astra-connectors/src/postgres_destination.rs
@@ -1,0 +1,333 @@
+use anyhow::{anyhow, bail, Context};
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader};
+use tokio_postgres::NoTls;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PostgresDestinationConfig {
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    #[serde(default, rename = "passwordRef")]
+    pub password_ref: Option<String>,
+    #[serde(default, rename = "sslMode")]
+    pub ssl_mode: Option<String>,
+    #[serde(default)]
+    pub schema: Option<String>,
+    #[serde(default, rename = "tablePrefix")]
+    pub table_prefix: Option<String>,
+    #[serde(default, rename = "applicationName")]
+    pub application_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RawLoadChunkResult {
+    pub object_key: String,
+    pub table_name: String,
+    pub rows_written: u64,
+    pub skipped: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RawLoadReport {
+    pub destination_kind: String,
+    pub schema: String,
+    pub applied_chunks: Vec<RawLoadChunkResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PostgresDestinationLoader {
+    config: PostgresDestinationConfig,
+}
+
+impl PostgresDestinationLoader {
+    pub fn from_spec(spec: &astra_yaml::AstraSpec) -> anyhow::Result<Self> {
+        if spec.destination.kind != "postgres" {
+            bail!(
+                "expected destination.kind=postgres, got {}",
+                spec.destination.kind
+            );
+        }
+        let values = spec
+            .destination
+            .connection
+            .as_ref()
+            .context("destination.connection is required for postgres destination loading")?;
+        Ok(Self {
+            config: PostgresDestinationConfig {
+                host: require_string(values, "host")?,
+                port: require_u16(values, "port")?,
+                database: require_string(values, "database")?,
+                username: require_string(values, "username")?,
+                password_ref: optional_string(values, "passwordRef")?,
+                ssl_mode: optional_string(values, "sslMode")?,
+                schema: optional_string(values, "schema")?,
+                table_prefix: optional_string(values, "tablePrefix")?,
+                application_name: optional_string(values, "applicationName")?,
+            },
+        })
+    }
+
+    pub fn config(&self) -> &PostgresDestinationConfig {
+        &self.config
+    }
+
+    pub async fn load_local_stage_chunks(
+        &self,
+        chunks: Vec<(astra_runtime::StageChunk, Vec<u8>)>,
+    ) -> anyhow::Result<RawLoadReport> {
+        let mut pg_config = tokio_postgres::Config::new();
+        pg_config.host(&self.config.host);
+        pg_config.port(self.config.port);
+        pg_config.dbname(&self.config.database);
+        pg_config.user(&self.config.username);
+        if let Some(application_name) = &self.config.application_name {
+            pg_config.application_name(application_name);
+        }
+        if let Some(password_ref) = &self.config.password_ref {
+            if let Some(password) = resolve_password_ref(password_ref)? {
+                pg_config.password(password);
+            }
+        }
+
+        let (mut client, connection) = pg_config
+            .connect(NoTls)
+            .await
+            .context("failed to connect to Postgres destination")?;
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                tracing::error!(?error, "postgres destination connection task exited");
+            }
+        });
+
+        let schema = self
+            .config
+            .schema
+            .clone()
+            .unwrap_or_else(|| "astra_raw".to_string());
+        ensure_metadata_tables(&client, &schema).await?;
+
+        let mut applied_chunks = Vec::new();
+        for (chunk, bytes) in chunks {
+            let table_name = raw_table_name(
+                &schema,
+                self.config.table_prefix.as_deref().unwrap_or("raw_"),
+                &chunk.stream_name,
+            );
+            let skipped = load_chunk(&mut client, &schema, &table_name, &chunk, &bytes).await?;
+            let rows_written = if skipped { 0 } else { chunk.row_count };
+            applied_chunks.push(RawLoadChunkResult {
+                object_key: chunk.object_key,
+                table_name,
+                rows_written,
+                skipped,
+            });
+        }
+
+        Ok(RawLoadReport {
+            destination_kind: "postgres".to_string(),
+            schema,
+            applied_chunks,
+        })
+    }
+}
+
+async fn ensure_metadata_tables(
+    client: &tokio_postgres::Client,
+    schema: &str,
+) -> anyhow::Result<()> {
+    client
+        .batch_execute(&format!(
+            "CREATE SCHEMA IF NOT EXISTS {schema_ident};\n             CREATE TABLE IF NOT EXISTS {schema_ident}._applied_chunks (\n               object_key text PRIMARY KEY,\n               pipeline_name text NOT NULL,\n               stream_name text NOT NULL,\n               sequence bigint NOT NULL,\n               row_count bigint NOT NULL,\n               loaded_at timestamptz NOT NULL DEFAULT now()\n             );",
+            schema_ident = quote_ident(schema)
+        ))
+        .await
+        .with_context(|| format!("failed to initialize destination schema {}", schema))?;
+    Ok(())
+}
+
+async fn load_chunk(
+    client: &mut tokio_postgres::Client,
+    schema: &str,
+    table_name: &str,
+    chunk: &astra_runtime::StageChunk,
+    bytes: &[u8],
+) -> anyhow::Result<bool> {
+    let txn = client.transaction().await?;
+    let inserted = txn
+        .execute(
+            &format!(
+                "INSERT INTO {schema_ident}._applied_chunks (object_key, pipeline_name, stream_name, sequence, row_count)\n                 VALUES ($1, $2, $3, $4, $5)\n                 ON CONFLICT (object_key) DO NOTHING",
+                schema_ident = quote_ident(schema)
+            ),
+            &[
+                &chunk.object_key,
+                &chunk.pipeline_name,
+                &chunk.stream_name,
+                &(chunk.sequence as i64),
+                &(chunk.row_count as i64),
+            ],
+        )
+        .await?;
+
+    if inserted == 0 {
+        txn.rollback().await.ok();
+        return Ok(true);
+    }
+
+    txn.batch_execute(&format!(
+        "CREATE TABLE IF NOT EXISTS {table_ident} (\n           _object_key text NOT NULL,\n           _sequence bigint NOT NULL,\n           _row_number bigint NOT NULL,\n           _loaded_at timestamptz NOT NULL DEFAULT now(),\n           _data jsonb NOT NULL,\n           PRIMARY KEY (_object_key, _row_number)\n         );",
+        table_ident = table_name
+    ))
+    .await
+    .with_context(|| format!("failed to initialize raw table {table_name}"))?;
+
+    for (row_number, value) in decode_jsonl_gzip(bytes)?.into_iter().enumerate() {
+        txn.execute(
+            &format!(
+                "INSERT INTO {table_ident} (_object_key, _sequence, _row_number, _data) VALUES ($1, $2, $3, $4)",
+                table_ident = table_name
+            ),
+            &[
+                &chunk.object_key,
+                &(chunk.sequence as i64),
+                &((row_number + 1) as i64),
+                &value,
+            ],
+        )
+        .await
+        .with_context(|| format!("failed to insert raw row {} into {}", row_number + 1, table_name))?;
+    }
+
+    txn.commit().await?;
+    Ok(false)
+}
+
+fn decode_jsonl_gzip(bytes: &[u8]) -> anyhow::Result<Vec<serde_json::Value>> {
+    let decoder = GzDecoder::new(bytes);
+    let reader = BufReader::new(decoder);
+    let mut rows = Vec::new();
+    for (line_number, line) in reader.lines().enumerate() {
+        let line =
+            line.with_context(|| format!("failed to read gzipped JSONL line {}", line_number + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        rows.push(
+            serde_json::from_str(trimmed)
+                .with_context(|| format!("invalid JSONL payload on line {}", line_number + 1))?,
+        );
+    }
+    Ok(rows)
+}
+
+fn raw_table_name(schema: &str, prefix: &str, stream_name: &str) -> String {
+    format!(
+        "{}.{}",
+        quote_ident(schema),
+        quote_ident(&format!("{}{}", prefix, sanitize_ident(stream_name)))
+    )
+}
+
+fn sanitize_ident(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+    while out.contains("__") {
+        out = out.replace("__", "_");
+    }
+    out.trim_matches('_').to_string()
+}
+
+fn quote_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn require_string(
+    values: &BTreeMap<String, serde_yaml::Value>,
+    key: &str,
+) -> anyhow::Result<String> {
+    match values.get(key) {
+        Some(serde_yaml::Value::String(value)) if !value.trim().is_empty() => Ok(value.clone()),
+        Some(_) => bail!("destination.connection.{key} must be a non-empty string"),
+        None => bail!("destination.connection.{key} is required"),
+    }
+}
+
+fn optional_string(
+    values: &BTreeMap<String, serde_yaml::Value>,
+    key: &str,
+) -> anyhow::Result<Option<String>> {
+    match values.get(key) {
+        None | Some(serde_yaml::Value::Null) => Ok(None),
+        Some(serde_yaml::Value::String(value)) if value.trim().is_empty() => Ok(None),
+        Some(serde_yaml::Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => bail!("destination.connection.{key} must be a string"),
+    }
+}
+
+fn require_u16(values: &BTreeMap<String, serde_yaml::Value>, key: &str) -> anyhow::Result<u16> {
+    match values.get(key) {
+        Some(serde_yaml::Value::Number(value)) => value
+            .as_u64()
+            .and_then(|n| u16::try_from(n).ok())
+            .ok_or_else(|| anyhow!("destination.connection.{key} must be a valid port")),
+        Some(serde_yaml::Value::String(value)) => value
+            .parse::<u16>()
+            .with_context(|| format!("destination.connection.{key} must be a valid port")),
+        Some(_) => bail!("destination.connection.{key} must be a valid port"),
+        None => bail!("destination.connection.{key} is required"),
+    }
+}
+
+fn resolve_password_ref(password_ref: &str) -> anyhow::Result<Option<String>> {
+    if let Some(env_name) = password_ref.strip_prefix("env:") {
+        return std::env::var(env_name)
+            .ok()
+            .filter(|value| !value.is_empty())
+            .map(Some)
+            .ok_or_else(|| anyhow!("environment variable {env_name} is not set for passwordRef"));
+    }
+    bail!("passwordRef currently supports env:NAME for local Postgres testing")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
+
+    #[test]
+    fn decodes_jsonl_gzip_payload() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(
+                br#"{"id":1}
+{"id":2}
+"#,
+            )
+            .unwrap();
+        let bytes = encoder.finish().unwrap();
+        let rows = decode_jsonl_gzip(&bytes).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], 1);
+        assert_eq!(rows[1]["id"], 2);
+    }
+
+    #[test]
+    fn sanitizes_stream_names_for_raw_tables() {
+        assert_eq!(
+            raw_table_name("astra_raw", "raw_", "public.orders"),
+            "\"astra_raw\".\"raw_public_orders\""
+        );
+    }
+}

--- a/crates/astra-runtime/src/lib.rs
+++ b/crates/astra-runtime/src/lib.rs
@@ -222,6 +222,83 @@ impl LocalStageChunkStore {
             .filter(|segment| !segment.is_empty())
             .fold(self.bucket_root(), |path, segment| path.join(segment))
     }
+
+    pub fn list_chunks_for_pipeline(&self, pipeline_name: &str) -> Result<Vec<StageChunk>> {
+        let mut chunks = Vec::new();
+        let prefix = self.config.storage.normalized_prefix();
+        let base = if prefix.is_empty() {
+            self.bucket_root()
+        } else {
+            self.bucket_root().join(&prefix)
+        }
+        .join("pipelines")
+        .join(pipeline_name)
+        .join("streams");
+
+        if !base.exists() {
+            return Ok(chunks);
+        }
+
+        let stream_dirs = fs::read_dir(&base)
+            .with_context(|| format!("failed to list staged streams under {}", base.display()))?;
+        for stream_dir in stream_dirs {
+            let stream_dir = stream_dir?;
+            if !stream_dir.file_type()?.is_dir() {
+                continue;
+            }
+            let stream_name = stream_dir.file_name().to_string_lossy().to_string();
+            let chunks_dir = stream_dir
+                .path()
+                .join("partitions")
+                .join("default")
+                .join("chunks");
+            if !chunks_dir.exists() {
+                continue;
+            }
+            for entry in fs::read_dir(&chunks_dir).with_context(|| {
+                format!(
+                    "failed to list staged chunks under {}",
+                    chunks_dir.display()
+                )
+            })? {
+                let entry = entry?;
+                if !entry.file_type()?.is_file() {
+                    continue;
+                }
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                if !file_name.ends_with(".jsonl.gz") {
+                    continue;
+                }
+                let sequence = parse_sequence(&file_name)?;
+                let object_key =
+                    self.config
+                        .storage
+                        .chunk_key(pipeline_name, &stream_name, "default", sequence);
+                let bytes_written = entry.metadata()?.len();
+                chunks.push(StageChunk {
+                    pipeline_name: pipeline_name.to_string(),
+                    stream_name: stream_name.clone(),
+                    partition_key: "default".to_string(),
+                    sequence,
+                    bucket: self.config.storage.bucket.clone(),
+                    object_key,
+                    bytes_written,
+                    row_count: 0,
+                    content_type: STAGING_CONTENT_TYPE_JSONL.to_string(),
+                    content_encoding: STAGING_CONTENT_ENCODING_GZIP.to_string(),
+                    schema_fingerprint: None,
+                    created_at_unix_ms: 0,
+                });
+            }
+        }
+
+        chunks.sort_by(|a, b| {
+            a.stream_name
+                .cmp(&b.stream_name)
+                .then(a.sequence.cmp(&b.sequence))
+        });
+        Ok(chunks)
+    }
 }
 
 #[async_trait]
@@ -385,6 +462,13 @@ fn required_env(name: &str) -> Result<String> {
     std::env::var(name).with_context(|| format!("missing {name}"))
 }
 
+fn parse_sequence(file_name: &str) -> Result<u64> {
+    let trimmed = file_name.trim_end_matches(".jsonl.gz");
+    trimmed
+        .parse::<u64>()
+        .with_context(|| format!("invalid staged chunk sequence in file name {file_name}"))
+}
+
 fn unix_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -465,6 +549,50 @@ mod tests {
 
         let bytes = store.read_chunk(&chunk).await.expect("chunk reads");
         assert_eq!(bytes, b"pretend-gzip-jsonl");
+
+        fs::remove_dir_all(root_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn local_store_lists_chunks_for_pipeline() {
+        let root_dir = temp_root("list");
+        let store = LocalStageChunkStore::new(LocalStagingConfig {
+            root_dir: root_dir.clone(),
+            storage: StagingConfig {
+                kind: StagingKind::Local,
+                bucket: "astra-staging".to_string(),
+                prefix: "dev".to_string(),
+            },
+        });
+
+        store
+            .write_chunk(StageChunkRequest {
+                pipeline_name: "postgres-analytics".to_string(),
+                stream_name: "public.orders".to_string(),
+                partition_key: "default".to_string(),
+                sequence: 2,
+                payload: StageChunkPayload::jsonl_gzip(1, vec![1, 2, 3]),
+            })
+            .await
+            .unwrap();
+        store
+            .write_chunk(StageChunkRequest {
+                pipeline_name: "postgres-analytics".to_string(),
+                stream_name: "public.users".to_string(),
+                partition_key: "default".to_string(),
+                sequence: 1,
+                payload: StageChunkPayload::jsonl_gzip(1, vec![4, 5, 6]),
+            })
+            .await
+            .unwrap();
+
+        let chunks = store
+            .list_chunks_for_pipeline("postgres-analytics")
+            .unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].stream_name, "public.orders");
+        assert_eq!(chunks[0].sequence, 2);
+        assert_eq!(chunks[1].stream_name, "public.users");
 
         fs::remove_dir_all(root_dir).ok();
     }

--- a/crates/astra-yaml/src/lib.rs
+++ b/crates/astra-yaml/src/lib.rs
@@ -91,6 +91,8 @@ pub enum SnapshotMode {
 pub struct Destination {
     pub kind: String,
     #[serde(default)]
+    pub connection: Option<BTreeMap<String, serde_yaml::Value>>,
+    #[serde(default)]
     pub staging: Option<Staging>,
     pub write: WriteBehavior,
 }
@@ -201,6 +203,11 @@ impl AstraSpec {
         for value in self.source.connection.values() {
             validate_secret_ref_value(value)?;
         }
+        if let Some(connection) = &self.destination.connection {
+            for value in connection.values() {
+                validate_secret_ref_value(value)?;
+            }
+        }
         Ok(())
     }
 }
@@ -235,5 +242,14 @@ mod tests {
         let raw = include_str!("../../../examples/postgres-to-warehouse.astra.yaml");
         let spec = AstraSpec::parse_yaml(raw).expect("spec parses");
         spec.validate().expect("spec validates");
+    }
+
+    #[test]
+    fn parses_destination_connection_when_present() {
+        let raw = include_str!("../../../examples/postgres-to-postgres-raw.astra.yaml");
+        let spec = AstraSpec::parse_yaml(raw).expect("spec parses");
+        spec.validate().expect("spec validates");
+        assert_eq!(spec.destination.kind, "postgres");
+        assert!(spec.destination.connection.is_some());
     }
 }

--- a/docs/architecture/staging-contract.md
+++ b/docs/architecture/staging-contract.md
@@ -94,6 +94,24 @@ Current v0.1 behavior:
 
 The runtime crate now includes `MinioStageChunkStore`, and the CLI exposes `snapshot-to-minio-staging` so the same snapshot flow can write directly into a local Podman-managed MinIO instance.
 
+## First destination loader: local Postgres raw tables
+Issue #37 starts with the least delusional destination apply path:
+- read staged `JSONL.gz` chunks from the local staging adapter
+- connect to a self-hosted/local Postgres destination
+- create a raw schema (default `astra_raw`) if it does not exist
+- create one raw table per captured stream, with names derived from the stream (`public.orders` -> `raw_public_orders` by default)
+- insert each JSON document into a `_data jsonb` column plus loader metadata columns
+- track applied chunk object keys in `astra_raw._applied_chunks` so re-running the loader skips already applied chunks instead of duplicating them forever
+
+Current raw table shape:
+- `_object_key text`
+- `_sequence bigint`
+- `_row_number bigint`
+- `_loaded_at timestamptz default now()`
+- `_data jsonb`
+
+This is intentionally narrow. It is not pretending to be merge/upsert semantics yet. It gives Astra a real, self-hostable destination leg that can be run locally under Podman without inventing warehouse-specific nonsense too early.
+
 ## Podman-based local development
 The repo ships a MinIO service in the local Podman Compose stack.
 
@@ -116,8 +134,15 @@ cargo run -p astra -- snapshot-to-minio-staging examples/postgres-to-warehouse.a
 
 If MinIO is not running, the filesystem adapter is still the cheapest dev/test loop.
 
+For the Postgres raw loader, a local/self-hosted setup can skip MinIO entirely and stage to the filesystem:
+1. run a source Postgres and destination Postgres (or separate DBs on one instance)
+2. snapshot to `.astra/staging`
+3. load the staged chunks into the destination raw schema
+
 ## Open questions
 - whether v0.1 should standardize on JSONL.gz or allow Parquet early
 - whether a separate apply ledger is cleaner than embedding sink commit markers in checkpoints
 - when to introduce per-destination staging format negotiation
 - when it becomes worth splitting staging backends into a dedicated storage crate instead of keeping the first two adapters in `astra-runtime`
+- when the Postgres raw loader should graduate from row-by-row inserts to `COPY`-based bulk loading
+- how soon to add normalized/table-shaped destination writers on top of the raw landing zone

--- a/examples/postgres-to-postgres-raw.astra.yaml
+++ b/examples/postgres-to-postgres-raw.astra.yaml
@@ -1,0 +1,46 @@
+version: v1alpha1
+pipeline:
+  name: postgres-raw-local
+  mode: snapshot
+  schedule: manual
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.users
+      - public.orders
+    snapshot:
+      mode: full
+      chunkSize: 50000
+destination:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: warehouse
+    username: warehouse_user
+    passwordRef: env:WAREHOUSE_PASSWORD
+    schema: astra_raw
+    tablePrefix: raw_
+    applicationName: astra-loader
+  staging:
+    kind: local
+    bucket: astra-staging
+    prefix: postgres-raw-local/
+  write:
+    mode: append
+    batchSize: 100000
+runtime:
+  parallelism:
+    tables: 2
+  checkpointing:
+    intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause


### PR DESCRIPTION
## Summary
- add a local Postgres raw destination loader for staged JSONL.gz chunks
- create raw landing schema/tables on demand
- track applied chunk object keys to skip duplicate reruns
- add spec/config/docs support for local Postgres destination loading

## Validation
- `cargo fmt --all`
- `cargo test --quiet`
- real Podman-backed smoke test:
  - seed source Postgres tables
  - run `snapshot-to-local-staging`
  - run `load-local-staging-to-postgres`
  - rerun load and verify duplicate chunks are skipped
  - verify expected raw row counts and applied chunk count in Postgres

## Notes
- raw landing only for now (`jsonb` in `astra_raw.*`)
- no COPY optimization yet
- local/self-hosted scope only
