### PR TITLE
OpenClaw: persist pipeline runs and staged artifacts

### DIFF
--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -14,6 +14,18 @@ pub fn routes() -> Router<AppState> {
         .route("/ready", get(health::ready))
         .route("/version", get(health::version))
         .route("/api/v1/pipelines", get(pipelines::list_pipelines))
+        .route(
+            "/api/v1/pipelines/:pipeline_name/runs",
+            get(pipelines::list_pipeline_runs),
+        )
+        .route(
+            "/api/v1/pipeline-runs",
+            post(pipelines::create_pipeline_run),
+        )
+        .route(
+            "/api/v1/pipeline-runs/:pipeline_run_id/artifacts",
+            post(pipelines::record_staged_artifact).get(pipelines::list_staged_artifacts),
+        )
         .route("/api/v1/specs/apply", post(pipelines::apply_spec))
         .route(
             "/api/v1/examples/postgres-to-warehouse",

--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -1,9 +1,16 @@
 use crate::{
     error::AppError,
-    models::api::{ApplySpecRequest, PipelinesResponse},
+    models::api::{
+        ApplySpecRequest, CreatePipelineRunRequest, PipelineRunsResponse, PipelinesResponse,
+        RecordStagedArtifactRequest, StagedArtifactsResponse,
+    },
     state::AppState,
 };
-use axum::{extract::State, Json};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use uuid::Uuid;
 
 pub async fn list_pipelines(
     State(state): State<AppState>,
@@ -24,4 +31,90 @@ pub async fn apply_spec(
         .apply_spec(request.yaml, request.created_by)
         .await?;
     Ok(Json(response))
+}
+
+pub async fn create_pipeline_run(
+    State(state): State<AppState>,
+    Json(request): Json<CreatePipelineRunRequest>,
+) -> Result<Json<crate::models::api::PipelineRunResponse>, AppError> {
+    if request.pipeline_name.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "pipeline_name must not be empty".to_string(),
+        ));
+    }
+    if request.trigger_mode.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "trigger_mode must not be empty".to_string(),
+        ));
+    }
+
+    let response = state
+        .pipeline_service
+        .create_pipeline_run(
+            request.pipeline_name,
+            request.trigger_mode,
+            request.status,
+            request.worker_id,
+            request.started_at,
+        )
+        .await?;
+    Ok(Json(response))
+}
+
+pub async fn list_pipeline_runs(
+    State(state): State<AppState>,
+    Path(pipeline_name): Path<String>,
+) -> Result<Json<PipelineRunsResponse>, AppError> {
+    let runs = state
+        .pipeline_service
+        .list_pipeline_runs(&pipeline_name)
+        .await?;
+    Ok(Json(PipelineRunsResponse { runs }))
+}
+
+pub async fn record_staged_artifact(
+    State(state): State<AppState>,
+    Path(pipeline_run_id): Path<Uuid>,
+    Json(request): Json<RecordStagedArtifactRequest>,
+) -> Result<Json<crate::models::api::StagedArtifactResponse>, AppError> {
+    if request.stream_name.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "stream_name must not be empty".to_string(),
+        ));
+    }
+    if request.object_key.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "object_key must not be empty".to_string(),
+        ));
+    }
+
+    let response = state
+        .pipeline_service
+        .record_staged_artifact(
+            pipeline_run_id,
+            request.stream_name,
+            request.partition_key,
+            request.sequence,
+            request.bucket,
+            request.object_key,
+            request.bytes_written,
+            request.row_count,
+            request.content_type,
+            request.content_encoding,
+            request.schema_fingerprint,
+            request.metadata_json,
+        )
+        .await?;
+    Ok(Json(response))
+}
+
+pub async fn list_staged_artifacts(
+    State(state): State<AppState>,
+    Path(pipeline_run_id): Path<Uuid>,
+) -> Result<Json<StagedArtifactsResponse>, AppError> {
+    let artifacts = state
+        .pipeline_service
+        .list_staged_artifacts(pipeline_run_id)
+        .await?;
+    Ok(Json(StagedArtifactsResponse { artifacts }))
 }

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -1,4 +1,6 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Serialize)]
 pub struct PipelineSummaryResponse {
@@ -27,4 +29,74 @@ pub struct ApplySpecResponse {
     pub spec_version: i32,
     pub content_hash: String,
     pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePipelineRunRequest {
+    pub pipeline_name: String,
+    pub trigger_mode: String,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub worker_id: Option<String>,
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PipelineRunResponse {
+    pub id: Uuid,
+    pub pipeline_name: String,
+    pub trigger_mode: String,
+    pub status: String,
+    pub worker_id: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PipelineRunsResponse {
+    pub runs: Vec<PipelineRunResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordStagedArtifactRequest {
+    pub stream_name: String,
+    pub partition_key: String,
+    pub sequence: i64,
+    pub bucket: String,
+    pub object_key: String,
+    pub bytes_written: i64,
+    pub row_count: i64,
+    pub content_type: String,
+    pub content_encoding: String,
+    #[serde(default)]
+    pub schema_fingerprint: Option<String>,
+    #[serde(default)]
+    pub metadata_json: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StagedArtifactResponse {
+    pub id: Uuid,
+    pub pipeline_run_id: Uuid,
+    pub stream_name: String,
+    pub partition_key: String,
+    pub sequence: i64,
+    pub bucket: String,
+    pub object_key: String,
+    pub bytes_written: i64,
+    pub row_count: i64,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub schema_fingerprint: Option<String>,
+    pub metadata_json: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StagedArtifactsResponse {
+    pub artifacts: Vec<StagedArtifactResponse>,
 }

--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -1,4 +1,8 @@
-use crate::repositories::{AppliedPipelineRecord, PipelineRecord, PipelineRepository};
+use crate::repositories::{
+    AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
+    PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use chrono::Utc;
 use sha2::{Digest, Sha256};
@@ -9,6 +13,8 @@ use uuid::Uuid;
 #[derive(Default, Clone)]
 pub struct InMemoryPipelineRepository {
     inner: Arc<RwLock<HashMap<String, StoredPipeline>>>,
+    runs: Arc<RwLock<HashMap<Uuid, PipelineRunRecord>>>,
+    artifacts: Arc<RwLock<HashMap<Uuid, Vec<StagedArtifactRecord>>>>,
 }
 
 #[derive(Clone)]
@@ -81,6 +87,111 @@ impl PipelineRepository for InMemoryPipelineRepository {
             pipeline: record,
             content_hash,
         })
+    }
+
+    async fn create_pipeline_run(
+        &self,
+        run: CreatePipelineRunRecord,
+    ) -> anyhow::Result<PipelineRunRecord> {
+        let pipelines = self.inner.read().await;
+        if !pipelines.contains_key(&run.pipeline_name) {
+            return Err(anyhow!("pipeline '{}' does not exist", run.pipeline_name));
+        }
+        drop(pipelines);
+
+        let now = Utc::now();
+        let record = PipelineRunRecord {
+            id: Uuid::new_v4(),
+            pipeline_name: run.pipeline_name,
+            trigger_mode: run.trigger_mode,
+            status: run.status,
+            worker_id: run.worker_id,
+            started_at: run.started_at,
+            finished_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        self.runs.write().await.insert(record.id, record.clone());
+        Ok(record)
+    }
+
+    async fn list_pipeline_runs(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>> {
+        let mut runs: Vec<_> = self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| run.pipeline_name == pipeline_name)
+            .cloned()
+            .collect();
+        runs.sort_by(|a, b| {
+            b.started_at
+                .cmp(&a.started_at)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+        Ok(runs)
+    }
+
+    async fn record_staged_artifact(
+        &self,
+        artifact: RecordStagedArtifactRecord,
+    ) -> anyhow::Result<StagedArtifactRecord> {
+        let runs = self.runs.read().await;
+        if !runs.contains_key(&artifact.pipeline_run_id) {
+            return Err(anyhow!(
+                "pipeline run '{}' does not exist",
+                artifact.pipeline_run_id
+            ));
+        }
+        drop(runs);
+
+        let record = StagedArtifactRecord {
+            id: Uuid::new_v4(),
+            pipeline_run_id: artifact.pipeline_run_id,
+            stream_name: artifact.stream_name,
+            partition_key: artifact.partition_key,
+            sequence: artifact.sequence,
+            bucket: artifact.bucket,
+            object_key: artifact.object_key,
+            bytes_written: artifact.bytes_written,
+            row_count: artifact.row_count,
+            content_type: artifact.content_type,
+            content_encoding: artifact.content_encoding,
+            schema_fingerprint: artifact.schema_fingerprint,
+            metadata_json: artifact.metadata_json,
+            created_at: Utc::now(),
+        };
+
+        let mut artifacts = self.artifacts.write().await;
+        artifacts
+            .entry(record.pipeline_run_id)
+            .or_default()
+            .push(record.clone());
+        Ok(record)
+    }
+
+    async fn list_staged_artifacts(
+        &self,
+        pipeline_run_id: Uuid,
+    ) -> anyhow::Result<Vec<StagedArtifactRecord>> {
+        let mut artifacts = self
+            .artifacts
+            .read()
+            .await
+            .get(&pipeline_run_id)
+            .cloned()
+            .unwrap_or_default();
+        artifacts.sort_by(|a, b| {
+            a.stream_name
+                .cmp(&b.stream_name)
+                .then_with(|| a.partition_key.cmp(&b.partition_key))
+                .then_with(|| a.sequence.cmp(&b.sequence))
+        });
+        Ok(artifacts)
     }
 }
 

--- a/apps/control-plane/src/repositories/mod.rs
+++ b/apps/control-plane/src/repositories/mod.rs
@@ -2,4 +2,7 @@ pub mod memory;
 pub mod pipeline_repository;
 pub mod postgres;
 
-pub use pipeline_repository::{AppliedPipelineRecord, PipelineRecord, PipelineRepository};
+pub use pipeline_repository::{
+    AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
+    PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+};

--- a/apps/control-plane/src/repositories/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/pipeline_repository.rs
@@ -1,4 +1,7 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct PipelineRecord {
@@ -15,6 +18,62 @@ pub struct AppliedPipelineRecord {
     pub content_hash: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct CreatePipelineRunRecord {
+    pub pipeline_name: String,
+    pub trigger_mode: String,
+    pub status: String,
+    pub worker_id: Option<String>,
+    pub started_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineRunRecord {
+    pub id: Uuid,
+    pub pipeline_name: String,
+    pub trigger_mode: String,
+    pub status: String,
+    pub worker_id: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordStagedArtifactRecord {
+    pub pipeline_run_id: Uuid,
+    pub stream_name: String,
+    pub partition_key: String,
+    pub sequence: i64,
+    pub bucket: String,
+    pub object_key: String,
+    pub bytes_written: i64,
+    pub row_count: i64,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub schema_fingerprint: Option<String>,
+    pub metadata_json: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct StagedArtifactRecord {
+    pub id: Uuid,
+    pub pipeline_run_id: Uuid,
+    pub stream_name: String,
+    pub partition_key: String,
+    pub sequence: i64,
+    pub bucket: String,
+    pub object_key: String,
+    pub bytes_written: i64,
+    pub row_count: i64,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub schema_fingerprint: Option<String>,
+    pub metadata_json: Value,
+    pub created_at: DateTime<Utc>,
+}
+
 #[async_trait]
 pub trait PipelineRepository: Send + Sync {
     async fn list_pipelines(&self) -> anyhow::Result<Vec<PipelineRecord>>;
@@ -24,4 +83,20 @@ pub trait PipelineRepository: Send + Sync {
         raw_yaml: String,
         created_by: Option<String>,
     ) -> anyhow::Result<AppliedPipelineRecord>;
+    async fn create_pipeline_run(
+        &self,
+        run: CreatePipelineRunRecord,
+    ) -> anyhow::Result<PipelineRunRecord>;
+    async fn list_pipeline_runs(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>>;
+    async fn record_staged_artifact(
+        &self,
+        artifact: RecordStagedArtifactRecord,
+    ) -> anyhow::Result<StagedArtifactRecord>;
+    async fn list_staged_artifacts(
+        &self,
+        pipeline_run_id: Uuid,
+    ) -> anyhow::Result<Vec<StagedArtifactRecord>>;
 }

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -1,11 +1,14 @@
-use crate::repositories::{AppliedPipelineRecord, PipelineRecord, PipelineRepository};
+use crate::repositories::{
+    AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
+    PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+};
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tokio_postgres::{types::Json, Client, NoTls};
+use tokio_postgres::{types::Json, Client, NoTls, Row};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -64,6 +67,44 @@ impl PostgresPipelineRepository {
                     UNIQUE (pipeline_id, version),
                     UNIQUE (pipeline_id, content_hash)
                 );
+
+                CREATE TABLE IF NOT EXISTS pipeline_runs (
+                    id UUID PRIMARY KEY,
+                    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+                    trigger_mode TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    worker_id TEXT,
+                    started_at TIMESTAMPTZ NOT NULL,
+                    finished_at TIMESTAMPTZ,
+                    stats_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pipeline_started_at
+                    ON pipeline_runs (pipeline_id, started_at DESC);
+
+                CREATE TABLE IF NOT EXISTS staged_artifacts (
+                    id UUID PRIMARY KEY,
+                    pipeline_run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+                    stream_name TEXT NOT NULL,
+                    partition_key TEXT NOT NULL,
+                    sequence BIGINT NOT NULL,
+                    bucket TEXT NOT NULL,
+                    object_key TEXT NOT NULL,
+                    bytes_written BIGINT NOT NULL,
+                    row_count BIGINT NOT NULL,
+                    content_type TEXT NOT NULL,
+                    content_encoding TEXT NOT NULL,
+                    schema_fingerprint TEXT,
+                    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE (pipeline_run_id, object_key),
+                    UNIQUE (pipeline_run_id, stream_name, partition_key, sequence)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_staged_artifacts_run_stream_sequence
+                    ON staged_artifacts (pipeline_run_id, stream_name, partition_key, sequence);
                 "#,
             )
             .await
@@ -239,6 +280,172 @@ impl PipelineRepository for PostgresPipelineRepository {
             },
             content_hash,
         })
+    }
+
+    async fn create_pipeline_run(
+        &self,
+        run: CreatePipelineRunRecord,
+    ) -> anyhow::Result<PipelineRunRecord> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_one(
+                r#"
+                INSERT INTO pipeline_runs (id, pipeline_id, trigger_mode, status, worker_id, started_at)
+                SELECT $1, p.id, $2, $3, $4, $5
+                FROM pipelines p
+                WHERE p.name = $6
+                RETURNING id, trigger_mode, status, worker_id, started_at, finished_at, created_at, updated_at
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &run.trigger_mode,
+                    &run.status,
+                    &run.worker_id,
+                    &run.started_at,
+                    &run.pipeline_name,
+                ],
+            )
+            .await
+            .with_context(|| format!("failed to create pipeline run for '{}'", run.pipeline_name))?;
+
+        Ok(PipelineRunRecord {
+            id: row.get("id"),
+            pipeline_name: run.pipeline_name,
+            trigger_mode: row.get("trigger_mode"),
+            status: row.get("status"),
+            worker_id: row.get("worker_id"),
+            started_at: row.get("started_at"),
+            finished_at: row.get("finished_at"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        })
+    }
+
+    async fn list_pipeline_runs(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT pr.id, p.name AS pipeline_name, pr.trigger_mode, pr.status, pr.worker_id,
+                       pr.started_at, pr.finished_at, pr.created_at, pr.updated_at
+                FROM pipeline_runs pr
+                INNER JOIN pipelines p ON p.id = pr.pipeline_id
+                WHERE p.name = $1
+                ORDER BY pr.started_at DESC, pr.created_at DESC
+                "#,
+                &[&pipeline_name],
+            )
+            .await
+            .with_context(|| format!("failed to list runs for pipeline '{}'", pipeline_name))?;
+
+        Ok(rows.into_iter().map(map_pipeline_run_row).collect())
+    }
+
+    async fn record_staged_artifact(
+        &self,
+        artifact: RecordStagedArtifactRecord,
+    ) -> anyhow::Result<StagedArtifactRecord> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_one(
+                r#"
+                INSERT INTO staged_artifacts (
+                    id, pipeline_run_id, stream_name, partition_key, sequence, bucket, object_key,
+                    bytes_written, row_count, content_type, content_encoding, schema_fingerprint, metadata_json
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                RETURNING id, pipeline_run_id, stream_name, partition_key, sequence, bucket, object_key,
+                          bytes_written, row_count, content_type, content_encoding, schema_fingerprint,
+                          metadata_json, created_at
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &artifact.pipeline_run_id,
+                    &artifact.stream_name,
+                    &artifact.partition_key,
+                    &artifact.sequence,
+                    &artifact.bucket,
+                    &artifact.object_key,
+                    &artifact.bytes_written,
+                    &artifact.row_count,
+                    &artifact.content_type,
+                    &artifact.content_encoding,
+                    &artifact.schema_fingerprint,
+                    &Json(&artifact.metadata_json),
+                ],
+            )
+            .await
+            .with_context(|| format!("failed to record staged artifact for run '{}'", artifact.pipeline_run_id))?;
+
+        Ok(map_staged_artifact_row(row))
+    }
+
+    async fn list_staged_artifacts(
+        &self,
+        pipeline_run_id: Uuid,
+    ) -> anyhow::Result<Vec<StagedArtifactRecord>> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT id, pipeline_run_id, stream_name, partition_key, sequence, bucket, object_key,
+                       bytes_written, row_count, content_type, content_encoding, schema_fingerprint,
+                       metadata_json, created_at
+                FROM staged_artifacts
+                WHERE pipeline_run_id = $1
+                ORDER BY stream_name ASC, partition_key ASC, sequence ASC
+                "#,
+                &[&pipeline_run_id],
+            )
+            .await
+            .with_context(|| format!("failed to list staged artifacts for run '{}'", pipeline_run_id))?;
+
+        Ok(rows.into_iter().map(map_staged_artifact_row).collect())
+    }
+}
+
+fn map_pipeline_run_row(row: Row) -> PipelineRunRecord {
+    PipelineRunRecord {
+        id: row.get("id"),
+        pipeline_name: row.get("pipeline_name"),
+        trigger_mode: row.get("trigger_mode"),
+        status: row.get("status"),
+        worker_id: row.get("worker_id"),
+        started_at: row.get("started_at"),
+        finished_at: row.get("finished_at"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn map_staged_artifact_row(row: Row) -> StagedArtifactRecord {
+    let metadata_json: Json<Value> = row.get("metadata_json");
+    StagedArtifactRecord {
+        id: row.get("id"),
+        pipeline_run_id: row.get("pipeline_run_id"),
+        stream_name: row.get("stream_name"),
+        partition_key: row.get("partition_key"),
+        sequence: row.get("sequence"),
+        bucket: row.get("bucket"),
+        object_key: row.get("object_key"),
+        bytes_written: row.get("bytes_written"),
+        row_count: row.get("row_count"),
+        content_type: row.get("content_type"),
+        content_encoding: row.get("content_encoding"),
+        schema_fingerprint: row.get("schema_fingerprint"),
+        metadata_json: metadata_json.0,
+        created_at: row.get("created_at"),
     }
 }
 

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -1,8 +1,12 @@
 use crate::{
-    models::api::{ApplySpecResponse, PipelineSummaryResponse},
-    repositories::PipelineRepository,
+    models::api::{
+        ApplySpecResponse, PipelineRunResponse, PipelineSummaryResponse, StagedArtifactResponse,
+    },
+    repositories::{CreatePipelineRunRecord, PipelineRepository, RecordStagedArtifactRecord},
 };
+use chrono::Utc;
 use std::sync::Arc;
+use uuid::Uuid;
 
 pub struct PipelineService {
     repository: Arc<dyn PipelineRepository>,
@@ -41,5 +45,136 @@ impl PipelineService {
             content_hash: applied.content_hash,
             message: "pipeline spec applied".to_string(),
         })
+    }
+
+    pub async fn create_pipeline_run(
+        &self,
+        pipeline_name: String,
+        trigger_mode: String,
+        status: Option<String>,
+        worker_id: Option<String>,
+        started_at: Option<chrono::DateTime<Utc>>,
+    ) -> anyhow::Result<PipelineRunResponse> {
+        let run = self
+            .repository
+            .create_pipeline_run(CreatePipelineRunRecord {
+                pipeline_name,
+                trigger_mode,
+                status: status.unwrap_or_else(|| "running".to_string()),
+                worker_id,
+                started_at: started_at.unwrap_or_else(Utc::now),
+            })
+            .await?;
+        Ok(PipelineRunResponse {
+            id: run.id,
+            pipeline_name: run.pipeline_name,
+            trigger_mode: run.trigger_mode,
+            status: run.status,
+            worker_id: run.worker_id,
+            started_at: run.started_at,
+            finished_at: run.finished_at,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+        })
+    }
+
+    pub async fn list_pipeline_runs(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Vec<PipelineRunResponse>> {
+        let runs = self.repository.list_pipeline_runs(pipeline_name).await?;
+        Ok(runs
+            .into_iter()
+            .map(|run| PipelineRunResponse {
+                id: run.id,
+                pipeline_name: run.pipeline_name,
+                trigger_mode: run.trigger_mode,
+                status: run.status,
+                worker_id: run.worker_id,
+                started_at: run.started_at,
+                finished_at: run.finished_at,
+                created_at: run.created_at,
+                updated_at: run.updated_at,
+            })
+            .collect())
+    }
+
+    pub async fn record_staged_artifact(
+        &self,
+        pipeline_run_id: Uuid,
+        stream_name: String,
+        partition_key: String,
+        sequence: i64,
+        bucket: String,
+        object_key: String,
+        bytes_written: i64,
+        row_count: i64,
+        content_type: String,
+        content_encoding: String,
+        schema_fingerprint: Option<String>,
+        metadata_json: Option<serde_json::Value>,
+    ) -> anyhow::Result<StagedArtifactResponse> {
+        let artifact = self
+            .repository
+            .record_staged_artifact(RecordStagedArtifactRecord {
+                pipeline_run_id,
+                stream_name,
+                partition_key,
+                sequence,
+                bucket,
+                object_key,
+                bytes_written,
+                row_count,
+                content_type,
+                content_encoding,
+                schema_fingerprint,
+                metadata_json: metadata_json.unwrap_or_else(|| serde_json::json!({})),
+            })
+            .await?;
+        Ok(StagedArtifactResponse {
+            id: artifact.id,
+            pipeline_run_id: artifact.pipeline_run_id,
+            stream_name: artifact.stream_name,
+            partition_key: artifact.partition_key,
+            sequence: artifact.sequence,
+            bucket: artifact.bucket,
+            object_key: artifact.object_key,
+            bytes_written: artifact.bytes_written,
+            row_count: artifact.row_count,
+            content_type: artifact.content_type,
+            content_encoding: artifact.content_encoding,
+            schema_fingerprint: artifact.schema_fingerprint,
+            metadata_json: artifact.metadata_json,
+            created_at: artifact.created_at,
+        })
+    }
+
+    pub async fn list_staged_artifacts(
+        &self,
+        pipeline_run_id: Uuid,
+    ) -> anyhow::Result<Vec<StagedArtifactResponse>> {
+        let artifacts = self
+            .repository
+            .list_staged_artifacts(pipeline_run_id)
+            .await?;
+        Ok(artifacts
+            .into_iter()
+            .map(|artifact| StagedArtifactResponse {
+                id: artifact.id,
+                pipeline_run_id: artifact.pipeline_run_id,
+                stream_name: artifact.stream_name,
+                partition_key: artifact.partition_key,
+                sequence: artifact.sequence,
+                bucket: artifact.bucket,
+                object_key: artifact.object_key,
+                bytes_written: artifact.bytes_written,
+                row_count: artifact.row_count,
+                content_type: artifact.content_type,
+                content_encoding: artifact.content_encoding,
+                schema_fingerprint: artifact.schema_fingerprint,
+                metadata_json: artifact.metadata_json,
+                created_at: artifact.created_at,
+            })
+            .collect())
     }
 }


### PR DESCRIPTION
## Summary
- persist `pipeline_runs` and `staged_artifacts` in control-plane storage
- add thin API endpoints to create/list runs and attach/list artifact metadata
- support both Postgres-backed and in-memory backends

## Validation
- `cargo test -p astra-control-plane --quiet`
- real control-plane API smoke test against Postgres backend:
  - apply a pipeline
  - create a pipeline run
  - attach staged artifact metadata
  - list runs by pipeline
  - list artifacts by run

## Notes
- groundwork only; not full orchestration/state transitions yet
