### PR TITLE
OpenClaw: add local snapshot checkpoint resume slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,22 @@ export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
 cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
 ```
 
-That flow reuses the Postgres connector for discovery plus snapshot reads, converts rows to JSONL.gz in-process, and writes one staged chunk per captured table via the filesystem-backed staging adapter.
+That flow now does the first non-hand-wavy useful slice: it can paginate snapshot reads into multiple staged JSONL.gz chunks, persist a local checkpoint ledger under `.astra/checkpoints`, and resume from the next unfinished chunk on rerun. The implementation is still intentionally local-first and narrow: offset-based chunk pagination for Podman/dev workflows, no sink apply yet, and no fake cloud dependencies.
+
+Example:
+
+```bash
+export POSTGRES_PASSWORD=...
+export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
+export ASTRA_CHECKPOINT_LOCAL_ROOT=.astra/checkpoints
+cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --chunk-size 5000
+```
+
+Useful flags:
+
+- `--chunk-size <rows>` overrides `source.capture.snapshot.chunkSize`
+- `--checkpoint-root <dir>` changes where the local resume ledger is stored
+- `--no-resume` ignores any existing ledger and starts from chunk sequence 0 again
 
 There is now a matching narrow-but-real destination leg for local/self-hosted Postgres raw loading:
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -3,12 +3,13 @@ use astra_connectors::{
     PostgresDestinationLoader, PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions,
 };
 use astra_runtime::{
-    LocalStageChunkStore, LocalStagingConfig, MinioStageChunkStore, MinioStagingConfig,
-    StageChunkPayload, StageChunkRequest, StageChunkStore, StagingConfig, StagingKind,
+    LocalCheckpointStore, LocalStageChunkStore, LocalStagingConfig, MinioStageChunkStore,
+    MinioStagingConfig, SnapshotCheckpointLedger, StageChunkPayload, StageChunkRequest,
+    StageChunkStore, StagingConfig, StagingKind,
 };
 use astra_yaml::AstraSpec;
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 #[derive(Parser)]
 #[command(name = "astra", about = "Astra CLI", version)]
@@ -25,13 +26,19 @@ enum Commands {
     Apply { file: String },
     /// Discover schema details for a Postgres source using a local/self-hosted database
     DiscoverSource { file: String },
-    /// Execute a minimal local Postgres snapshot and write staged chunks to the filesystem adapter
+    /// Execute a local Postgres snapshot, chunk rows into staged files, and persist resume checkpoints
     SnapshotToLocalStaging {
         file: String,
         #[arg(long)]
         max_rows_per_table: Option<u64>,
         #[arg(long)]
         staging_root: Option<PathBuf>,
+        #[arg(long)]
+        checkpoint_root: Option<PathBuf>,
+        #[arg(long)]
+        chunk_size: Option<u64>,
+        #[arg(long)]
+        no_resume: bool,
     },
     /// Execute a minimal local Postgres snapshot and write staged chunks to MinIO/S3-compatible storage
     SnapshotToMinioStaging {
@@ -66,7 +73,20 @@ async fn main() -> anyhow::Result<()> {
             file,
             max_rows_per_table,
             staging_root,
-        } => snapshot_to_local_staging(&file, max_rows_per_table, staging_root).await?,
+            checkpoint_root,
+            chunk_size,
+            no_resume,
+        } => {
+            snapshot_to_local_staging(
+                &file,
+                max_rows_per_table,
+                staging_root,
+                checkpoint_root,
+                chunk_size,
+                no_resume,
+            )
+            .await?
+        }
         Commands::SnapshotToMinioStaging {
             file,
             max_rows_per_table,
@@ -162,6 +182,9 @@ async fn snapshot_to_local_staging(
     file: &str,
     max_rows_per_table: Option<u64>,
     staging_root: Option<PathBuf>,
+    checkpoint_root: Option<PathBuf>,
+    chunk_size: Option<u64>,
+    no_resume: bool,
 ) -> anyhow::Result<()> {
     let spec = AstraSpec::from_file(file)?;
     spec.validate()?;
@@ -172,16 +195,45 @@ async fn snapshot_to_local_staging(
     let discovery = source
         .discover(PostgresDiscoverOptions { tables: vec![] })
         .await?;
-    let snapshot = source
-        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
-            tables: vec![],
-            max_rows_per_table,
-        })
-        .await?;
 
     let root_dir = staging_root
         .or_else(default_staging_root_from_env)
         .unwrap_or_else(|| PathBuf::from(".astra/staging"));
+    let checkpoint_root = checkpoint_root
+        .or_else(default_checkpoint_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/checkpoints"));
+    let checkpoint_store = LocalCheckpointStore::new(checkpoint_root.clone());
+    let existing_ledger = if no_resume {
+        SnapshotCheckpointLedger {
+            pipeline_name: spec.pipeline.name.clone(),
+            updated_at_unix_ms: 0,
+            tables: BTreeMap::new(),
+        }
+    } else {
+        checkpoint_store.load(&spec.pipeline.name)?
+    };
+
+    let start_sequence_by_table = existing_ledger
+        .tables
+        .iter()
+        .filter_map(|(table, checkpoint)| {
+            if checkpoint.completed {
+                None
+            } else {
+                Some((table.clone(), checkpoint.next_sequence))
+            }
+        })
+        .collect();
+
+    let snapshot = source
+        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
+            tables: vec![],
+            max_rows_per_table,
+            chunk_size,
+            start_sequence_by_table,
+        })
+        .await?;
+
     let store = LocalStageChunkStore::new(LocalStagingConfig {
         root_dir: root_dir.clone(),
         storage: StagingConfig {
@@ -192,10 +244,30 @@ async fn snapshot_to_local_staging(
     });
 
     store.ensure_ready().await?;
+    checkpoint_store.ensure_ready()?;
 
     println!("discovered postgres source: {}", spec.pipeline.name);
     println!("catalog tables: {}", discovery.catalog.tables.len());
     println!("local staging root: {}", root_dir.display());
+    println!("local checkpoint root: {}", checkpoint_root.display());
+    if no_resume {
+        println!("resume mode: disabled (--no-resume)");
+    } else {
+        let resumable = existing_ledger
+            .tables
+            .iter()
+            .filter(|(_, cp)| !cp.completed)
+            .count();
+        let completed = existing_ledger
+            .tables
+            .iter()
+            .filter(|(_, cp)| cp.completed)
+            .count();
+        println!(
+            "resume mode: enabled ({} resumable table(s), {} completed table(s) from ledger)",
+            resumable, completed
+        );
+    }
     println!("staged chunks:");
 
     for table in snapshot.tables {
@@ -208,6 +280,13 @@ async fn snapshot_to_local_staging(
                 payload: StageChunkPayload::jsonl_gzip(table.row_count, table.rows_jsonl_gzip),
             })
             .await?;
+        checkpoint_store.record_chunk_staged(
+            &spec.pipeline.name,
+            &table.table,
+            table.sequence,
+            chunk.row_count,
+            &chunk.object_key,
+        )?;
 
         let resolved = store.resolve_path(&chunk.object_key);
         println!(
@@ -218,10 +297,28 @@ async fn snapshot_to_local_staging(
         );
         println!("  sql: {}", table.sql);
         println!(
-            "  chunk: bucket={} key={} bytes={}",
-            chunk.bucket, chunk.object_key, chunk.bytes_written
+            "  chunk: bucket={} key={} bytes={} sequence={}",
+            chunk.bucket, chunk.object_key, chunk.bytes_written, chunk.sequence
         );
     }
+
+    println!("table progress:");
+    for progress in snapshot.table_progress {
+        if progress.finished {
+            checkpoint_store.mark_table_complete(&spec.pipeline.name, &progress.table)?;
+        }
+        println!(
+            "- {} -> next_sequence={} rows_emitted={} finished={}",
+            progress.table, progress.next_sequence, progress.rows_emitted, progress.finished
+        );
+    }
+
+    let final_ledger = checkpoint_store.load(&spec.pipeline.name)?;
+    println!(
+        "checkpoint ledger: {} ({} table checkpoint(s))",
+        checkpoint_store.ledger_path(&spec.pipeline.name).display(),
+        final_ledger.tables.len()
+    );
 
     Ok(())
 }
@@ -397,4 +494,8 @@ async fn load_local_staging_to_postgres(
 
 fn default_staging_root_from_env() -> Option<PathBuf> {
     std::env::var_os("ASTRA_STAGING_LOCAL_ROOT").map(PathBuf::from)
+}
+
+fn default_checkpoint_root_from_env() -> Option<PathBuf> {
+    std::env::var_os("ASTRA_CHECKPOINT_LOCAL_ROOT").map(PathBuf::from)
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -344,6 +344,8 @@ async fn snapshot_to_minio_staging(
         .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
             tables: vec![],
             max_rows_per_table,
+            chunk_size: None,
+            start_sequence_by_table: BTreeMap::new(),
         })
         .await?;
 

--- a/crates/astra-connectors/src/lib.rs
+++ b/crates/astra-connectors/src/lib.rs
@@ -4,8 +4,8 @@ pub mod postgres_destination;
 pub use postgres::{
     ColumnSchema, DiscoverReport, PostgresCdcSettings, PostgresConnectionConfig,
     PostgresDiscoverOptions, PostgresSnapshotPlan, PostgresSource, PostgresSourceConfig,
-    SnapshotExecutionOptions, SnapshotExecutionReport, SnapshotTableChunk, SourceCatalog,
-    SourceTable,
+    SnapshotExecutionOptions, SnapshotExecutionReport, SnapshotTableChunk, SnapshotTableProgress,
+    SourceCatalog, SourceTable,
 };
 pub use postgres_destination::{
     PostgresDestinationConfig, PostgresDestinationLoader, RawLoadChunkResult, RawLoadReport,

--- a/crates/astra-connectors/src/postgres.rs
+++ b/crates/astra-connectors/src/postgres.rs
@@ -84,12 +84,16 @@ pub struct DiscoverReport {
     pub snapshot_plan: PostgresSnapshotPlan,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SnapshotExecutionOptions {
     #[serde(default)]
     pub tables: Vec<String>,
     #[serde(default)]
     pub max_rows_per_table: Option<u64>,
+    #[serde(default)]
+    pub chunk_size: Option<u64>,
+    #[serde(default)]
+    pub start_sequence_by_table: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -102,9 +106,18 @@ pub struct SnapshotTableChunk {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotTableProgress {
+    pub table: String,
+    pub next_sequence: u64,
+    pub finished: bool,
+    pub rows_emitted: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SnapshotExecutionReport {
     pub source_kind: String,
     pub tables: Vec<SnapshotTableChunk>,
+    pub table_progress: Vec<SnapshotTableProgress>,
 }
 
 pub struct PostgresSource {
@@ -202,37 +215,106 @@ impl PostgresSource {
 
         let client = connect(&self.config.connection).await?;
         let mut tables = Vec::new();
+        let mut table_progress = Vec::new();
+        let configured_chunk_size = options.chunk_size.or_else(|| {
+            self.config
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.chunk_size)
+        });
 
         for table_name in target_tables {
-            let sql = build_snapshot_json_sql(&table_name, options.max_rows_per_table)?;
-            let rows = client
-                .query(&sql, &[])
-                .await
-                .with_context(|| format!("failed to snapshot table {table_name}"))?;
+            let start_sequence = options
+                .start_sequence_by_table
+                .get(&table_name)
+                .copied()
+                .unwrap_or(0);
+            let mut next_sequence = start_sequence;
+            let mut rows_emitted = 0_u64;
+            let mut finished = false;
 
-            let mut jsonl = Vec::new();
-            let mut row_count = 0_u64;
-            for row in rows {
-                let value: serde_json::Value = read_json_value(&row, "record")?;
-                serde_json::to_writer(&mut jsonl, &value)
-                    .with_context(|| format!("failed to encode staged row for {table_name}"))?;
-                jsonl.push(b'\n');
-                row_count += 1;
+            if let Some(base_chunk_size) = configured_chunk_size {
+                if base_chunk_size == 0 {
+                    bail!("snapshot chunk size must be greater than zero");
+                }
+
+                loop {
+                    let offset = next_sequence.saturating_mul(base_chunk_size);
+                    let remaining = options
+                        .max_rows_per_table
+                        .map(|max_rows| max_rows.saturating_sub(offset));
+
+                    if matches!(remaining, Some(0)) {
+                        break;
+                    }
+
+                    let limit = remaining
+                        .map(|rows| rows.min(base_chunk_size))
+                        .unwrap_or(base_chunk_size);
+                    let sql = build_snapshot_json_sql(&table_name, Some(limit), Some(offset))?;
+                    let rows = client
+                        .query(&sql, &[])
+                        .await
+                        .with_context(|| format!("failed to snapshot table {table_name}"))?;
+
+                    if rows.is_empty() {
+                        finished = true;
+                        break;
+                    }
+
+                    let row_count = rows.len() as u64;
+                    let rows_jsonl_gzip = encode_rows_as_gzip_jsonl(&rows, &table_name)?;
+                    tables.push(SnapshotTableChunk {
+                        table: table_name.clone(),
+                        sql,
+                        row_count,
+                        sequence: next_sequence,
+                        rows_jsonl_gzip,
+                    });
+
+                    rows_emitted = rows_emitted.saturating_add(row_count);
+                    next_sequence += 1;
+
+                    if row_count < limit {
+                        finished = true;
+                        break;
+                    }
+                }
+            } else {
+                let sql = build_snapshot_json_sql(&table_name, options.max_rows_per_table, None)?;
+                let rows = client
+                    .query(&sql, &[])
+                    .await
+                    .with_context(|| format!("failed to snapshot table {table_name}"))?;
+                let row_count = rows.len() as u64;
+                let rows_jsonl_gzip = encode_rows_as_gzip_jsonl(&rows, &table_name)?;
+                tables.push(SnapshotTableChunk {
+                    table: table_name.clone(),
+                    sql,
+                    row_count,
+                    sequence: next_sequence,
+                    rows_jsonl_gzip,
+                });
+                rows_emitted = row_count;
+                next_sequence += 1;
+                finished = options
+                    .max_rows_per_table
+                    .map(|limit| row_count < limit)
+                    .unwrap_or(true);
             }
 
-            let rows_jsonl_gzip = gzip_bytes(&jsonl)?;
-            tables.push(SnapshotTableChunk {
+            table_progress.push(SnapshotTableProgress {
                 table: table_name,
-                sql,
-                row_count,
-                sequence: 0,
-                rows_jsonl_gzip,
+                next_sequence,
+                finished,
+                rows_emitted,
             });
         }
 
         Ok(SnapshotExecutionReport {
             source_kind: "postgres".to_string(),
             tables,
+            table_progress,
         })
     }
 }
@@ -443,15 +525,37 @@ fn quote_qualified_table(table_name: &str) -> String {
     )
 }
 
-fn build_snapshot_json_sql(table_name: &str, max_rows: Option<u64>) -> anyhow::Result<String> {
+fn build_snapshot_json_sql(
+    table_name: &str,
+    limit: Option<u64>,
+    offset: Option<u64>,
+) -> anyhow::Result<String> {
     let table = quote_qualified_table(table_name);
     let mut sql = format!(
         "SELECT to_jsonb(snapshot_row) AS record FROM (SELECT * FROM {table}) AS snapshot_row"
     );
-    if let Some(limit) = max_rows {
+    if let Some(limit) = limit {
         sql.push_str(&format!(" LIMIT {limit}"));
     }
+    if let Some(offset) = offset {
+        sql.push_str(&format!(" OFFSET {offset}"));
+    }
     Ok(sql)
+}
+
+fn encode_rows_as_gzip_jsonl(
+    rows: &[tokio_postgres::Row],
+    table_name: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let mut jsonl = Vec::new();
+    for row in rows {
+        let value: serde_json::Value = read_json_value(row, "record")?;
+        serde_json::to_writer(&mut jsonl, &value)
+            .with_context(|| format!("failed to encode staged row for {table_name}"))?;
+        jsonl.push(b'\n');
+    }
+
+    gzip_bytes(&jsonl)
 }
 
 fn read_json_value(row: &tokio_postgres::Row, column: &str) -> anyhow::Result<serde_json::Value> {
@@ -519,7 +623,15 @@ mod tests {
     #[test]
     fn snapshot_json_sql_wraps_rows_as_json() {
         assert_eq!(
-            build_snapshot_json_sql("public.orders", Some(25)).expect("sql builds"),
+            build_snapshot_json_sql("public.orders", Some(25), Some(50)).expect("sql builds"),
+            "SELECT to_jsonb(snapshot_row) AS record FROM (SELECT * FROM \"public\".\"orders\") AS snapshot_row LIMIT 25 OFFSET 50"
+        );
+    }
+
+    #[test]
+    fn snapshot_json_sql_omits_offset_when_not_requested() {
+        assert_eq!(
+            build_snapshot_json_sql("public.orders", Some(25), None).expect("sql builds"),
             "SELECT to_jsonb(snapshot_row) AS record FROM (SELECT * FROM \"public\".\"orders\") AS snapshot_row LIMIT 25"
         );
     }

--- a/crates/astra-runtime/src/lib.rs
+++ b/crates/astra-runtime/src/lib.rs
@@ -9,9 +9,10 @@ use aws_sdk_s3::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fs,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -431,6 +432,127 @@ impl StageChunkStore for MinioStageChunkStore {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SnapshotCheckpointLedger {
+    pub pipeline_name: String,
+    pub updated_at_unix_ms: u64,
+    #[serde(default)]
+    pub tables: BTreeMap<String, SnapshotTableCheckpoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SnapshotTableCheckpoint {
+    pub next_sequence: u64,
+    pub rows_staged: u64,
+    pub last_chunk_key: Option<String>,
+    pub completed: bool,
+    pub updated_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalCheckpointStore {
+    root_dir: PathBuf,
+}
+
+impl LocalCheckpointStore {
+    pub fn new(root_dir: PathBuf) -> Self {
+        Self { root_dir }
+    }
+
+    pub fn root_dir(&self) -> &Path {
+        &self.root_dir
+    }
+
+    pub fn ensure_ready(&self) -> Result<()> {
+        fs::create_dir_all(&self.root_dir).with_context(|| {
+            format!(
+                "failed to create local checkpoint root at {}",
+                self.root_dir.display()
+            )
+        })
+    }
+
+    pub fn ledger_path(&self, pipeline_name: &str) -> PathBuf {
+        self.root_dir.join(format!(
+            "{}.snapshot-checkpoints.json",
+            sanitize_name(pipeline_name)
+        ))
+    }
+
+    pub fn load(&self, pipeline_name: &str) -> Result<SnapshotCheckpointLedger> {
+        self.ensure_ready()?;
+        let path = self.ledger_path(pipeline_name);
+        if !path.exists() {
+            return Ok(SnapshotCheckpointLedger {
+                pipeline_name: pipeline_name.to_string(),
+                updated_at_unix_ms: unix_time_ms(),
+                tables: BTreeMap::new(),
+            });
+        }
+
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read checkpoint ledger at {}", path.display()))?;
+        let mut ledger: SnapshotCheckpointLedger = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse checkpoint ledger at {}", path.display()))?;
+        if ledger.pipeline_name.is_empty() {
+            ledger.pipeline_name = pipeline_name.to_string();
+        }
+        Ok(ledger)
+    }
+
+    pub fn save(&self, ledger: &SnapshotCheckpointLedger) -> Result<()> {
+        self.ensure_ready()?;
+        let path = self.ledger_path(&ledger.pipeline_name);
+        let payload =
+            serde_json::to_vec_pretty(ledger).context("failed to encode checkpoint ledger")?;
+        let mut file = fs::File::create(&path)
+            .with_context(|| format!("failed to create checkpoint ledger at {}", path.display()))?;
+        file.write_all(&payload)
+            .with_context(|| format!("failed to write checkpoint ledger at {}", path.display()))?;
+        file.write_all(b"\n").with_context(|| {
+            format!("failed to finalize checkpoint ledger at {}", path.display())
+        })?;
+        file.sync_all()
+            .with_context(|| format!("failed to flush checkpoint ledger at {}", path.display()))
+    }
+
+    pub fn record_chunk_staged(
+        &self,
+        pipeline_name: &str,
+        table_name: &str,
+        sequence: u64,
+        row_count: u64,
+        chunk_key: &str,
+    ) -> Result<SnapshotCheckpointLedger> {
+        let mut ledger = self.load(pipeline_name)?;
+        let now = unix_time_ms();
+        let checkpoint = ledger.tables.entry(table_name.to_string()).or_default();
+        checkpoint.next_sequence = sequence + 1;
+        checkpoint.rows_staged = checkpoint.rows_staged.saturating_add(row_count);
+        checkpoint.last_chunk_key = Some(chunk_key.to_string());
+        checkpoint.completed = false;
+        checkpoint.updated_at_unix_ms = now;
+        ledger.updated_at_unix_ms = now;
+        self.save(&ledger)?;
+        Ok(ledger)
+    }
+
+    pub fn mark_table_complete(
+        &self,
+        pipeline_name: &str,
+        table_name: &str,
+    ) -> Result<SnapshotCheckpointLedger> {
+        let mut ledger = self.load(pipeline_name)?;
+        let now = unix_time_ms();
+        let checkpoint = ledger.tables.entry(table_name.to_string()).or_default();
+        checkpoint.completed = true;
+        checkpoint.updated_at_unix_ms = now;
+        ledger.updated_at_unix_ms = now;
+        self.save(&ledger)?;
+        Ok(ledger)
+    }
+}
+
 pub fn build_chunk_key(
     pipeline_name: &str,
     stream_name: &str,
@@ -444,6 +566,16 @@ pub fn build_chunk_key(
 
 fn normalize_prefix(prefix: &str) -> String {
     prefix.trim().trim_matches('/').to_string()
+}
+
+fn sanitize_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => ch,
+            _ => '-',
+        })
+        .collect()
 }
 
 fn ensure_chunk_belongs_to_bucket(expected_bucket: &str, chunk: &StageChunk) -> Result<()> {
@@ -652,5 +784,36 @@ mod tests {
         assert_eq!(config.region, DEFAULT_AWS_REGION);
         assert_eq!(config.access_key, "astra");
         assert_eq!(config.secret_key, "astrastorage");
+    }
+
+    #[test]
+    fn checkpoint_store_persists_resume_state() {
+        let root_dir = temp_root("checkpoint-store");
+        let store = LocalCheckpointStore::new(root_dir.clone());
+
+        store
+            .record_chunk_staged(
+                "postgres-analytics",
+                "public.orders",
+                0,
+                500,
+                "dev/pipelines/postgres-analytics/streams/public.orders/partitions/default/chunks/00000000000000000000.jsonl.gz",
+            )
+            .expect("checkpoint writes");
+        store
+            .mark_table_complete("postgres-analytics", "public.orders")
+            .expect("completion writes");
+
+        let ledger = store.load("postgres-analytics").expect("ledger loads");
+        let checkpoint = ledger.tables.get("public.orders").expect("table exists");
+        assert_eq!(checkpoint.next_sequence, 1);
+        assert_eq!(checkpoint.rows_staged, 500);
+        assert!(checkpoint.completed);
+        assert_eq!(
+            checkpoint.last_chunk_key.as_deref(),
+            Some("dev/pipelines/postgres-analytics/streams/public.orders/partitions/default/chunks/00000000000000000000.jsonl.gz")
+        );
+
+        fs::remove_dir_all(root_dir).ok();
     }
 }


### PR DESCRIPTION
## Summary
- add local snapshot checkpoint/resume groundwork for `snapshot-to-local-staging`
- support chunked snapshot reads with sequence tracking
- persist local checkpoint ledger state and allow resume on rerun
- add CLI flags for chunk size, checkpoint root, and resume control

## Validation
- `cargo test -p astra-runtime -p astra-connectors -p astra --quiet`
- real smoke test against local Postgres:
  - run snapshot with `--chunk-size 2`
  - verify multiple staged chunks are created per table
  - verify checkpoint ledger is written
  - rerun and confirm no extra chunks are emitted beyond the completed set

## Notes
- current resume strategy is local/dev oriented
- no production-grade CDC/checkpoint semantics claimed here
