### PR TITLE
OpenClaw: harden CI baseline for Rust and web foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   repo-sanity:
+    name: Repo sanity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,3 +22,34 @@ jobs:
         run: |
           echo "Astra scaffold present"
           find apps crates -maxdepth 2 -type f | sort
+
+  rust-foundation:
+    name: Rust foundation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+      - name: Check Rust workspace buildability
+        run: cargo check --workspace
+
+  web-foundation:
+    name: Web foundation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+      - name: Install web dependencies
+        run: npm ci
+      - name: Build web app
+        run: npm run build


### PR DESCRIPTION
## Summary
- keep the existing repo sanity lane
- add a Rust foundation lane that runs:
  - `cargo fmt --all --check`
  - `cargo check --workspace`
- add a Web foundation lane that runs:
  - `npm ci`
  - `npm run build` in `apps/web`
- split CI into clearer jobs so failures point to the broken lane instead of hiding in one mushy check

## Why
Current CI can pass while Rust or the web app is broken. This hardens the baseline so the repo validates actual foundations instead of mostly checking file presence.

## Validation
Ran locally:
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cd apps/web && npm ci`
- `cd apps/web && npm run build`

## Notes
- intentionally conservative: no `cargo test --workspace` lane yet
- no frontend lint/test lane yet
- this is baseline hardening, not final-form CI
