### PR TITLE
OpenClaw: clarify unsupported CDC execution paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Astra is an open-source data replication platform aiming to be the easy, fast al
 Astra v0.1 focuses on one real vertical slice:
 - configure a source and destination
 - run an initial snapshot/backfill
-- continue with incremental sync/CDC where supported
+- continue with incremental sync later; CDC is not executable yet in the current Postgres source skeleton
 - view job history and status in the UI
 - manage the same config via YAML
 
@@ -135,6 +135,8 @@ cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
 ```
 
 That currently does the minimum useful thing: parse and validate the Postgres source config, inspect table schemas from a reachable Postgres instance, and emit a snapshot-oriented SQL plan for the captured tables.
+
+CDC is still not executable in this skeleton. If a spec uses `pipeline.mode: cdc` or `source.capture.cdc`, `astra apply` and the control-plane apply API now reject it instead of pretending the runtime exists.
 
 There is also a first honest execution slice for local/self-hosted development:
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use astra_connectors::{
     PostgresDestinationLoader, PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions,
 };
@@ -130,12 +130,18 @@ fn validate(file: &str) -> anyhow::Result<()> {
     if let Some(source) = source {
         println!("postgres tables: {}", source.config().tables.join(", "));
     }
+    if spec.requests_cdc() {
+        println!(
+            "note: CDC settings are modeled in the spec, but Astra does not execute Postgres CDC yet; use discovery/snapshot commands only."
+        );
+    }
     Ok(())
 }
 
 fn apply(file: &str) -> anyhow::Result<()> {
     let spec = AstraSpec::from_file(file)?;
     spec.validate()?;
+    ensure_cdc_runtime_not_requested(&spec, "apply")?;
     println!("apply stub for validated pipeline: {}", spec.pipeline.name);
     println!("next step: send normalized spec to control-plane API");
     Ok(())
@@ -188,6 +194,7 @@ async fn snapshot_to_local_staging(
 ) -> anyhow::Result<()> {
     let spec = AstraSpec::from_file(file)?;
     spec.validate()?;
+    ensure_cdc_runtime_not_requested(&spec, "snapshot-to-local-staging")?;
     ensure_supported_snapshot_source(&spec)?;
 
     let staging = staging_from_spec(&spec)?;
@@ -326,6 +333,7 @@ async fn snapshot_to_minio_staging(
 ) -> anyhow::Result<()> {
     let spec = AstraSpec::from_file(file)?;
     spec.validate()?;
+    ensure_cdc_runtime_not_requested(&spec, "snapshot-to-minio-staging")?;
     ensure_supported_snapshot_source(&spec)?;
 
     let staging = staging_from_spec(&spec)?;
@@ -395,6 +403,16 @@ async fn snapshot_to_minio_staging(
 struct ResolvedStaging {
     bucket: String,
     prefix: String,
+}
+
+fn ensure_cdc_runtime_not_requested(spec: &AstraSpec, command: &str) -> anyhow::Result<()> {
+    if spec.requests_cdc() {
+        return Err(anyhow!(
+            "{command} does not execute CDC yet. Astra's Postgres source is currently limited to schema discovery and snapshot staging; remove pipeline.mode=cdc and source.capture.cdc for this command."
+        ));
+    }
+
+    Ok(())
 }
 
 fn ensure_supported_snapshot_source(spec: &AstraSpec) -> anyhow::Result<()> {
@@ -554,6 +572,49 @@ mod tests {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../examples/postgres-to-warehouse.astra.yaml");
         AstraSpec::from_file(path.to_str().expect("utf-8 path")).expect("sample spec loads")
+    }
+
+    #[test]
+    fn rejects_cdc_for_snapshot_commands() {
+        let spec = AstraSpec::parse_yaml(
+            r#"
+version: v1alpha1
+pipeline:
+  name: postgres-cdc
+  mode: cdc
+  schedule: continuous
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.users
+    cdc:
+      slotName: astra_slot
+      publicationName: astra_publication
+destination:
+  kind: snowflake
+  staging:
+    kind: s3
+    bucket: astra-staging
+  write:
+    mode: merge
+runtime: {}
+"#,
+        )
+        .expect("spec parses");
+
+        let error = ensure_cdc_runtime_not_requested(&spec, "snapshot-to-local-staging")
+            .expect_err("cdc should be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("snapshot-to-local-staging does not execute CDC yet"));
     }
 
     #[test]

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -38,6 +38,11 @@ impl PipelineService {
     ) -> anyhow::Result<ApplySpecResponse> {
         let spec = astra_yaml::AstraSpec::parse_yaml(&yaml)?;
         spec.validate()?;
+        if spec.requests_cdc() {
+            anyhow::bail!(
+                "spec apply does not execute CDC yet. Astra's Postgres source is currently limited to schema discovery and snapshot staging; remove pipeline.mode=cdc and source.capture.cdc before applying this spec."
+            );
+        }
         let applied = self.repository.apply_spec(spec, yaml, created_by).await?;
         Ok(ApplySpecResponse {
             pipeline_name: applied.pipeline.name,

--- a/crates/astra-yaml/src/lib.rs
+++ b/crates/astra-yaml/src/lib.rs
@@ -176,6 +176,10 @@ impl AstraSpec {
         Self::parse_yaml(&raw)
     }
 
+    pub fn requests_cdc(&self) -> bool {
+        self.pipeline.mode == PipelineMode::Cdc || self.source.capture.cdc.is_some()
+    }
+
     pub fn validate(&self) -> Result<(), ValidationError> {
         if self.version != SUPPORTED_VERSION {
             return Err(ValidationError::UnsupportedVersion(self.version.clone()));
@@ -251,5 +255,41 @@ mod tests {
         spec.validate().expect("spec validates");
         assert_eq!(spec.destination.kind, "postgres");
         assert!(spec.destination.connection.is_some());
+    }
+
+    #[test]
+    fn detects_when_a_spec_requests_cdc() {
+        let raw = r#"
+version: v1alpha1
+pipeline:
+  name: postgres-cdc
+  mode: cdc
+  schedule: continuous
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.users
+    cdc:
+      slotName: astra_slot
+      publicationName: astra_publication
+destination:
+  kind: snowflake
+  staging:
+    kind: s3
+    bucket: astra-staging
+  write:
+    mode: merge
+runtime: {}
+"#;
+        let spec = AstraSpec::parse_yaml(raw).expect("spec parses");
+
+        assert!(spec.requests_cdc());
     }
 }

--- a/docs/architecture/yaml-spec-draft.md
+++ b/docs/architecture/yaml-spec-draft.md
@@ -274,14 +274,14 @@ passwordRef: env:POSTGRES_PASSWORD
 
 ---
 
-## Example: Postgres to Snowflake
+## Example: Postgres snapshot to Snowflake staging
 
 ```yaml
 version: v1alpha1
 pipeline:
   name: postgres-analytics
-  mode: cdc
-  schedule: continuous
+  mode: snapshot
+  schedule: "0 * * * *"
 source:
   kind: postgres
   connection:
@@ -297,9 +297,6 @@ source:
     snapshot:
       mode: incremental
       chunkSize: 50000
-    cdc:
-      slotName: astra_slot
-      publicationName: astra_publication
 destination:
   kind: snowflake
   staging:
@@ -318,6 +315,8 @@ runtime:
     additiveChanges: auto-apply
     breakingChanges: pause
 ```
+
+> Note: the schema still models a `cdc` block for future connector work, but the current Postgres source skeleton only supports discovery and snapshot-oriented flows. CDC execution should fail loudly until that runtime exists.
 
 ---
 

--- a/examples/postgres-to-warehouse.astra.yaml
+++ b/examples/postgres-to-warehouse.astra.yaml
@@ -1,8 +1,8 @@
 version: v1alpha1
 pipeline:
   name: postgres-analytics
-  mode: cdc
-  schedule: continuous
+  mode: snapshot
+  schedule: "0 * * * *"
 source:
   kind: postgres
   connection:
@@ -18,9 +18,6 @@ source:
     snapshot:
       mode: incremental
       chunkSize: 50000
-    cdc:
-      slotName: astra_slot
-      publicationName: astra_publication
 destination:
   kind: snowflake
   staging:


### PR DESCRIPTION
## Summary
- add `AstraSpec::requests_cdc()` so execution/apply paths can detect CDC-requesting specs
- make CLI apply and snapshot staging commands fail loudly for unsupported CDC execution
- make control-plane `apply_spec` reject CDC-requesting specs explicitly
- update docs/examples so the default flow is honest about snapshot vs future CDC work

## Why
Astra currently models CDC-related settings, but executable behavior is still discovery/snapshot oriented. This PR tightens the truth boundary so CDC-shaped specs are no longer quietly treated like supported runtime behavior.

## Validation
- `cargo fmt`
- `cargo test -p astra-yaml -p astra --quiet`

## Notes
- `discover-source` still accepts CDC-configured specs because discovery is still useful and non-executing
- this PR clarifies unsupported behavior; it does not attempt to implement CDC runtime execution

Closes #51
