### PR TITLE
Add latest-run and run-history API surfaces (issue #70)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,161 @@
 # Contributing to Astra
 
+## Local bootstrap
+
+### Prerequisites
+- Rust toolchain (stable): `rustup` recommended
+- Node.js 18+ and npm (for web app)
+- Podman or Docker with Compose (for local Postgres + MinIO stack)
+
+### Clone and build
+
+```bash
+git clone https://github.com/Astra-Core/Astra.git
+cd Astra
+cargo build
+```
+
+### Start local infrastructure
+
+```bash
+podman compose -f deploy/docker-compose/docker-compose.yml up -d
+```
+
+Default local ports:
+- Postgres: `5432` (user: `astra`, password: `astra`, db: `astra`)
+- MinIO S3 API: `9000`
+- MinIO console: `9001`
+
+Stop with:
+
+```bash
+podman compose -f deploy/docker-compose/docker-compose.yml down
+```
+
+### Run tests
+
+```bash
+cargo test --workspace
+```
+
+### Build and run the web app
+
+```bash
+cd apps/web
+npm install
+npm run build
+cd ../..
+```
+
+The built frontend is served by the control plane at `http://127.0.0.1:8080`.
+
+### Run the control plane
+
+Without Postgres (in-memory mode):
+
+```bash
+cargo run -p astra-control-plane
+```
+
+With Postgres persistence:
+
+```bash
+export ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra
+cargo run -p astra-control-plane
+```
+
+## What works vs what is stubbed
+
+### Working flows (verified)
+- `cargo run -p astra -- validate examples/postgres-to-warehouse.astra.yaml` — validates a YAML spec
+- `cargo run -p astra -- apply examples/postgres-to-warehouse.astra.yaml` — apply stub (prints confirmation, does not yet persist to control plane from CLI)
+- `cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml` — discovers Postgres source schema (requires a reachable Postgres with the configured tables)
+- `cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000` — snapshots Postgres tables to local filesystem staging (requires reachable Postgres, set `POSTGRES_PASSWORD`)
+- `cargo run -p astra -- snapshot-to-minio-staging examples/postgres-to-postgres-raw.astra.yaml` — snapshots to MinIO staging (requires reachable Postgres and MinIO)
+- `cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml` — loads staged chunks into a raw Postgres destination (requires staged data and reachable destination Postgres)
+- Control plane pipeline list/apply API at `http://127.0.0.1:8080`
+- Web UI pipeline inventory and YAML editor at `http://127.0.0.1:8080`
+- YAML contract smoke test: `python3 scripts/yaml_contract_smoke.py`
+
+### Partial / requires infrastructure
+- `discover-source` and all snapshot/load commands require a reachable Postgres instance
+- MinIO staging requires a running MinIO instance
+- Postgres-backed control-plane persistence requires `ASTRA_DATABASE_URL`
+
+### Not yet implemented
+- CDC execution (explicitly rejected with a clear error message)
+- Single end-to-end orchestration command (individual steps exist, no unified command yet)
+- Run history / execution status in the web UI
+- Python connector runtime
+- Observability / structured diagnostics
+
+## Local snapshot quickstart
+
+This is the copy-paste path to validate the current local vertical slice.
+
+### 1. Start local infrastructure
+
+```bash
+podman compose -f deploy/docker-compose/docker-compose.yml up -d
+```
+
+### 2. Seed fixture data (if needed)
+
+Connect to the local Postgres and create test tables:
+
+```bash
+psql postgres://astra:astra@localhost:5432/astra -c "
+CREATE TABLE IF NOT EXISTS public.orders (
+  id SERIAL PRIMARY KEY,
+  customer TEXT NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
+  created_at TIMESTAMP DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS public.users (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT now()
+);
+INSERT INTO public.orders (customer, amount) VALUES ('alice', 99.99), ('bob', 149.50), ('carol', 75.00);
+INSERT INTO public.users (name, email) VALUES ('alice', 'alice@example.com'), ('bob', 'bob@example.com');
+"
+```
+
+### 3. Validate the spec
+
+```bash
+cargo run -p astra -- validate examples/postgres-to-warehouse.astra.yaml
+```
+
+Expected output includes: `valid Astra spec: postgres-analytics`
+
+### 4. Discover the source
+
+```bash
+export POSTGRES_PASSWORD=astra
+cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
+```
+
+Expected output includes discovered tables and a snapshot skeleton.
+
+### 5. Snapshot to local staging
+
+```bash
+export POSTGRES_PASSWORD=astra
+export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
+cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
+```
+
+Expected output includes staged chunk paths under `.astra/staging/`.
+
+### 6. Tear down
+
+```bash
+podman compose -f deploy/docker-compose/docker-compose.yml down
+rm -rf .astra/staging
+```
+
 ## Definition of done
 A change is done when:
 - acceptance criteria are satisfied
@@ -12,6 +168,3 @@ A change is done when:
 - keep architecture changes documented in `docs/architecture/` or `docs/decisions/`
 - if something is a stub, say it is a stub
 - do not pretend incomplete code is production-ready
-
-## Development
-Current bootstrap is scaffold-first. Until Rust is installed in the environment, code structure may be reviewed before compile validation is available.

--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -19,6 +19,14 @@ pub fn routes() -> Router<AppState> {
             get(pipelines::list_pipeline_runs),
         )
         .route(
+            "/api/v1/pipelines/:pipeline_name/latest-run",
+            get(pipelines::get_latest_run),
+        )
+        .route(
+            "/api/v1/pipelines/:pipeline_name/run-history",
+            get(pipelines::get_run_history),
+        )
+        .route(
             "/api/v1/pipeline-runs",
             post(pipelines::create_pipeline_run),
         )

--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -72,6 +72,29 @@ pub async fn list_pipeline_runs(
     Ok(Json(PipelineRunsResponse { runs }))
 }
 
+pub async fn get_latest_run(
+    State(state): State<AppState>,
+    Path(pipeline_name): Path<String>,
+) -> Result<Json<Option<crate::models::api::PipelineRunResponse>>, AppError> {
+    let run = state
+        .pipeline_service
+        .get_latest_run(&pipeline_name)
+        .await?;
+    Ok(Json(run))
+}
+
+pub async fn get_run_history(
+    State(state): State<AppState>,
+    Path(pipeline_name): Path<String>,
+) -> Result<Json<PipelineRunsResponse>, AppError> {
+    // Default limit of 10 runs if not specified
+    let runs = state
+        .pipeline_service
+        .get_run_history(&pipeline_name, 10)
+        .await?;
+    Ok(Json(PipelineRunsResponse { runs }))
+}
+
 pub async fn record_staged_artifact(
     State(state): State<AppState>,
     Path(pipeline_run_id): Path<Uuid>,

--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -136,6 +136,42 @@ impl PipelineRepository for InMemoryPipelineRepository {
         Ok(runs)
     }
 
+    async fn get_latest_run(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Option<PipelineRunRecord>> {
+        let runs = self.runs.read().await;
+        let mut matching: Vec<_> = runs
+            .values()
+            .filter(|run| run.pipeline_name == pipeline_name)
+            .cloned()
+            .collect();
+        matching.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(matching.into_iter().next())
+    }
+
+    async fn get_run_history(
+        &self,
+        pipeline_name: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>> {
+        let mut runs: Vec<_> = self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| run.pipeline_name == pipeline_name)
+            .cloned()
+            .collect();
+        runs.sort_by(|a, b| {
+            b.started_at
+                .cmp(&a.started_at)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+        runs.truncate(limit);
+        Ok(runs)
+    }
+
     async fn record_staged_artifact(
         &self,
         artifact: RecordStagedArtifactRecord,

--- a/apps/control-plane/src/repositories/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/pipeline_repository.rs
@@ -91,6 +91,15 @@ pub trait PipelineRepository: Send + Sync {
         &self,
         pipeline_name: &str,
     ) -> anyhow::Result<Vec<PipelineRunRecord>>;
+    async fn get_latest_run(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Option<PipelineRunRecord>>;
+    async fn get_run_history(
+        &self,
+        pipeline_name: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>>;
     async fn record_staged_artifact(
         &self,
         artifact: RecordStagedArtifactRecord,

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -369,7 +369,9 @@ impl PipelineRepository for PostgresPipelineRepository {
                 &[&pipeline_name],
             )
             .await
-            .with_context(|| format!("failed to get latest run for pipeline '{}'", pipeline_name))?;
+            .with_context(|| {
+                format!("failed to get latest run for pipeline '{}'", pipeline_name)
+            })?;
 
         Ok(row.map(map_pipeline_run_row))
     }
@@ -396,7 +398,9 @@ impl PipelineRepository for PostgresPipelineRepository {
                 &[&pipeline_name, &(limit as i64)],
             )
             .await
-            .with_context(|| format!("failed to get run history for pipeline '{}'", pipeline_name))?;
+            .with_context(|| {
+                format!("failed to get run history for pipeline '{}'", pipeline_name)
+            })?;
 
         Ok(rows.into_iter().map(map_pipeline_run_row).collect())
     }

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -348,6 +348,59 @@ impl PipelineRepository for PostgresPipelineRepository {
         Ok(rows.into_iter().map(map_pipeline_run_row).collect())
     }
 
+    async fn get_latest_run(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Option<PipelineRunRecord>> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                SELECT pr.id, p.name AS pipeline_name, pr.trigger_mode, pr.status, pr.worker_id,
+                       pr.started_at, pr.finished_at, pr.created_at, pr.updated_at
+                FROM pipeline_runs pr
+                INNER JOIN pipelines p ON p.id = pr.pipeline_id
+                WHERE p.name = $1
+                ORDER BY pr.started_at DESC, pr.created_at DESC
+                LIMIT 1
+                "#,
+                &[&pipeline_name],
+            )
+            .await
+            .with_context(|| format!("failed to get latest run for pipeline '{}'", pipeline_name))?;
+
+        Ok(row.map(map_pipeline_run_row))
+    }
+
+    async fn get_run_history(
+        &self,
+        pipeline_name: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<PipelineRunRecord>> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT pr.id, p.name AS pipeline_name, pr.trigger_mode, pr.status, pr.worker_id,
+                       pr.started_at, pr.finished_at, pr.created_at, pr.updated_at
+                FROM pipeline_runs pr
+                INNER JOIN pipelines p ON p.id = pr.pipeline_id
+                WHERE p.name = $1
+                ORDER BY pr.started_at DESC, pr.created_at DESC
+                LIMIT $2
+                "#,
+                &[&pipeline_name, &(limit as i64)],
+            )
+            .await
+            .with_context(|| format!("failed to get run history for pipeline '{}'", pipeline_name))?;
+
+        Ok(rows.into_iter().map(map_pipeline_run_row).collect())
+    }
+
     async fn record_staged_artifact(
         &self,
         artifact: RecordStagedArtifactRecord,

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -127,7 +127,10 @@ impl PipelineService {
         pipeline_name: &str,
         limit: usize,
     ) -> anyhow::Result<Vec<PipelineRunResponse>> {
-        let runs = self.repository.get_run_history(pipeline_name, limit).await?;
+        let runs = self
+            .repository
+            .get_run_history(pipeline_name, limit)
+            .await?;
         Ok(runs
             .into_iter()
             .map(|run| PipelineRunResponse {

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -104,6 +104,46 @@ impl PipelineService {
             .collect())
     }
 
+    pub async fn get_latest_run(
+        &self,
+        pipeline_name: &str,
+    ) -> anyhow::Result<Option<PipelineRunResponse>> {
+        let run = self.repository.get_latest_run(pipeline_name).await?;
+        Ok(run.map(|run| PipelineRunResponse {
+            id: run.id,
+            pipeline_name: run.pipeline_name,
+            trigger_mode: run.trigger_mode,
+            status: run.status,
+            worker_id: run.worker_id,
+            started_at: run.started_at,
+            finished_at: run.finished_at,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+        }))
+    }
+
+    pub async fn get_run_history(
+        &self,
+        pipeline_name: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<PipelineRunResponse>> {
+        let runs = self.repository.get_run_history(pipeline_name, limit).await?;
+        Ok(runs
+            .into_iter()
+            .map(|run| PipelineRunResponse {
+                id: run.id,
+                pipeline_name: run.pipeline_name,
+                trigger_mode: run.trigger_mode,
+                status: run.status,
+                worker_id: run.worker_id,
+                started_at: run.started_at,
+                finished_at: run.finished_at,
+                created_at: run.created_at,
+                updated_at: run.updated_at,
+            })
+            .collect())
+    }
+
     pub async fn record_staged_artifact(
         &self,
         pipeline_run_id: Uuid,


### PR DESCRIPTION
## Summary

Adds latest-run and run-history API surfaces for issue #70.

Closes #70

## Changes

- Add repository trait methods (get_latest_run, get_run_history)
- Implement in memory and postgres repositories
- Add service methods in pipeline_service.rs
- Add HTTP handlers and routes

## API Endpoints

- GET /api/v1/pipelines/:pipeline_name/latest-run - Get latest run for a pipeline
- GET /api/v1/pipelines/:pipeline_name/run-history - Get run history (default limit 10)

## Testing

- Smoke tests passed:
  - Health endpoint
  - latest-run with empty data (returns null)
  - run-history with empty data (returns [])
  - Create pipeline and runs
  - latest-run with data
  - run-history with multiple runs
  - Error cases (non-existent pipeline)