### PR TITLE
docs: v0.1 scope and limitations (closes #66)

### DIFF
--- a/docs/v0.1-SCOPE.md
+++ b/docs/v0.1-SCOPE.md
@@ -1,0 +1,27 @@
+# Astra v0.1 Scope and Known Limitations
+
+## In Scope
+
+- Snapshot-only Postgres → Postgres/Snowflake
+- Control-plane APIs
+- Local worker
+- Web UI basics
+- No CDC
+
+## Known Limitations
+
+- No CDC execution
+- No schema evolution
+- Local-only staging
+- No distributed workers
+- UI WIP
+
+## Future Work
+
+- CDC
+- Destinations
+- Cloud deploy
+- etc.
+
+See [release checklists (#67)](https://github.com/Astra-core/Astra/issues/67),
+[quickstart (#69)](https://github.com/Astra-core/Astra/issues/69).


### PR DESCRIPTION
Defines v0.1 boundaries + known gaps. Closes #66