### PR TITLE
fix: harden snapshot checkpoints w/ control-plane metadata (closes #39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "testcontainers",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,15 +49,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.125.0"
+version = "1.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223f5c95650d9557925a91f4c2db3def189e8f659452134a29e5cd2d37d708ed"
+checksum = "7878050a2321d215eec9db8be09f8db59418b53860ae86cc7042b4094d6cb2bb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -953,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3311,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -496,3 +496,8 @@ async fn load_local_staging_to_postgres(
 
 fn default_staging_root_from_env() -> Option<PathBuf> {
     std::env::var_os("ASTRA_STAGING_LOCAL_ROOT").map(PathBuf::from)
+}
+
+fn default_checkpoint_root_from_env() -> Option<PathBuf> {
+    std::env::var_os("ASTRA_CHECKPOINT_LOCAL_ROOT").map(PathBuf::from)
+}

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,4 +1,496 @@
+use anyhow::{bail, Context};
+use astra_connectors::{
+    PostgresDestinationLoader, PostgresDiscoverOptions, PostgresSource, SnapshotExecutionOptions,
+};
+use astra_runtime::{
+    LocalCheckpointStore, LocalStageChunkStore, LocalStagingConfig, MinioStageChunkStore,
+    MinioStagingConfig, SnapshotCheckpointLedger, StageChunkPayload, StageChunkRequest,
+    StageChunkStore, StagingConfig, StagingKind,
+};
+use astra_yaml::AstraSpec;
+use clap::{Parser, Subcommand};
+use std::{collections::BTreeMap, path::PathBuf};
+
+#[derive(Parser)]
+#[command(name = "astra", about = "Astra CLI", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Validate an Astra YAML spec
+    Validate { file: String },
+    /// Apply an Astra YAML spec to the control plane
+    Apply { file: String },
+    /// Discover schema details for a Postgres source using a local/self-hosted database
+    DiscoverSource { file: String },
+    /// Execute a local Postgres snapshot, chunk rows into staged files, and persist resume checkpoints
+    SnapshotToLocalStaging {
+        file: String,
+        #[arg(long)]
+        max_rows_per_table: Option<u64>,
+        #[arg(long)]
+        staging_root: Option<PathBuf>,
+        #[arg(long)]
+        checkpoint_root: Option<PathBuf>,
+        #[arg(long)]
+        chunk_size: Option<u64>,
+        #[arg(long)]
+        no_resume: bool,
+    },
+    /// Execute a minimal local Postgres snapshot and write staged chunks to MinIO/S3-compatible storage
+    SnapshotToMinioStaging {
+        file: String,
+        #[arg(long)]
+        max_rows_per_table: Option<u64>,
+        #[arg(long)]
+        endpoint: Option<String>,
+        #[arg(long)]
+        region: Option<String>,
+        #[arg(long)]
+        access_key: Option<String>,
+        #[arg(long)]
+        secret_key: Option<String>,
+    },
+    /// Load locally staged JSONL.gz chunks into raw Postgres destination tables
+    LoadLocalStagingToPostgres {
+        file: String,
+        #[arg(long)]
+        staging_root: Option<PathBuf>,
+    },
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    astra::run().await
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Validate { file } => validate(&file)?,
+        Commands::Apply { file } => apply(&file)?,
+        Commands::DiscoverSource { file } => discover_source(&file).await?,
+        Commands::SnapshotToLocalStaging {
+            file,
+            max_rows_per_table,
+            staging_root,
+            checkpoint_root,
+            chunk_size,
+            no_resume,
+        } => {
+            snapshot_to_local_staging(
+                &file,
+                max_rows_per_table,
+                staging_root,
+                checkpoint_root,
+                chunk_size,
+                no_resume,
+            )
+            .await?
+        }
+        Commands::SnapshotToMinioStaging {
+            file,
+            max_rows_per_table,
+            endpoint,
+            region,
+            access_key,
+            secret_key,
+        } => {
+            snapshot_to_minio_staging(
+                &file,
+                max_rows_per_table,
+                endpoint,
+                region,
+                access_key,
+                secret_key,
+            )
+            .await?
+        }
+        Commands::LoadLocalStagingToPostgres { file, staging_root } => {
+            load_local_staging_to_postgres(&file, staging_root).await?
+        }
+    }
+    Ok(())
 }
+
+fn validate(file: &str) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    let source = if spec.source.kind == "postgres" {
+        Some(PostgresSource::from_spec(&spec)?)
+    } else {
+        None
+    };
+
+    println!("valid Astra spec: {}", spec.pipeline.name);
+    println!("mode: {:?}", spec.pipeline.mode);
+    println!(
+        "source: {} -> destination: {}",
+        spec.source.kind, spec.destination.kind
+    );
+    if let Some(source) = source {
+        println!("postgres tables: {}", source.config().tables.join(", "));
+    }
+    Ok(())
+}
+
+fn apply(file: &str) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    println!("apply stub for validated pipeline: {}", spec.pipeline.name);
+    println!("next step: send normalized spec to control-plane API");
+    Ok(())
+}
+
+async fn discover_source(file: &str) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    let source = PostgresSource::from_spec(&spec)?;
+    let report = source
+        .discover(PostgresDiscoverOptions { tables: vec![] })
+        .await?;
+
+    println!("discovered postgres source: {}", spec.pipeline.name);
+    println!("tables:");
+    for table in &report.catalog.tables {
+        println!("- {}", table.fully_qualified_name);
+        if !table.primary_key.is_empty() {
+            println!("  primary key: {}", table.primary_key.join(", "));
+        }
+        for column in &table.columns {
+            println!(
+                "  - {}: {}{}",
+                column.name,
+                column.data_type,
+                if column.is_nullable {
+                    " (nullable)"
+                } else {
+                    ""
+                }
+            );
+        }
+    }
+
+    println!("snapshot skeleton:");
+    for table in &report.snapshot_plan.tables {
+        println!("- {} -> {}", table.table, table.sql);
+    }
+
+    Ok(())
+}
+
+async fn snapshot_to_local_staging(
+    file: &str,
+    max_rows_per_table: Option<u64>,
+    staging_root: Option<PathBuf>,
+    checkpoint_root: Option<PathBuf>,
+    chunk_size: Option<u64>,
+    no_resume: bool,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    ensure_supported_snapshot_source(&spec)?;
+
+    let staging = staging_from_spec(&spec)?;
+    let source = PostgresSource::from_spec(&spec)?;
+    let discovery = source
+        .discover(PostgresDiscoverOptions { tables: vec![] })
+        .await?;
+
+    let root_dir = staging_root
+        .or_else(default_staging_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/staging"));
+    let checkpoint_root = checkpoint_root
+        .or_else(default_checkpoint_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/checkpoints"));
+    let checkpoint_store = LocalCheckpointStore::new(checkpoint_root.clone());
+    let existing_ledger = if no_resume {
+        SnapshotCheckpointLedger {
+            pipeline_name: spec.pipeline.name.clone(),
+            updated_at_unix_ms: 0,
+            tables: BTreeMap::new(),
+        }
+    } else {
+        checkpoint_store.load(&spec.pipeline.name)?
+    };
+
+    let start_sequence_by_table = existing_ledger
+        .tables
+        .iter()
+        .filter_map(|(table, checkpoint)| {
+            if checkpoint.completed {
+                None
+            } else {
+                Some((table.clone(), checkpoint.next_sequence))
+            }
+        })
+        .collect();
+
+    let snapshot = source
+        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
+            tables: vec![],
+            max_rows_per_table,
+            chunk_size,
+            start_sequence_by_table,
+        })
+        .await?;
+
+    let store = LocalStageChunkStore::new(LocalStagingConfig {
+        root_dir: root_dir.clone(),
+        storage: StagingConfig {
+            kind: StagingKind::Local,
+            bucket: staging.bucket,
+            prefix: staging.prefix,
+        },
+    });
+
+    store.ensure_ready().await?;
+    checkpoint_store.ensure_ready()?;
+
+    println!("discovered postgres source: {}", spec.pipeline.name);
+    println!("catalog tables: {}", discovery.catalog.tables.len());
+    println!("local staging root: {}", root_dir.display());
+    println!("local checkpoint root: {}", checkpoint_root.display());
+    if no_resume {
+        println!("resume mode: disabled (--no-resume)");
+    } else {
+        let resumable = existing_ledger
+            .tables
+            .iter()
+            .filter(|(_, cp)| !cp.completed)
+            .count();
+        let completed = existing_ledger
+            .tables
+            .iter()
+            .filter(|(_, cp)| cp.completed)
+            .count();
+        println!(
+            "resume mode: enabled ({} resumable table(s), {} completed table(s) from ledger)",
+            resumable, completed
+        );
+    }
+    println!("staged chunks:");
+
+    for table in snapshot.tables {
+        let chunk = store
+            .write_chunk(StageChunkRequest {
+                pipeline_name: spec.pipeline.name.clone(),
+                stream_name: table.table.clone(),
+                partition_key: "default".to_string(),
+                sequence: table.sequence,
+                payload: StageChunkPayload::jsonl_gzip(table.row_count, table.rows_jsonl_gzip),
+            })
+            .await?;
+        checkpoint_store.record_chunk_staged(
+            &spec.pipeline.name,
+            &table.table,
+            table.sequence,
+            chunk.row_count,
+            &chunk.object_key,
+        )?;
+
+        let resolved = store.resolve_path(&chunk.object_key);
+        println!(
+            "- {} -> {} rows -> {}",
+            table.table,
+            chunk.row_count,
+            resolved.display()
+        );
+        println!("  sql: {}", table.sql);
+        println!(
+            "  chunk: bucket={} key={} bytes={} sequence={}",
+            chunk.bucket, chunk.object_key, chunk.bytes_written, chunk.sequence
+        );
+    }
+
+    println!("table progress:");
+    for progress in snapshot.table_progress {
+        if progress.finished {
+            checkpoint_store.mark_table_complete(&spec.pipeline.name, &progress.table)?;
+        }
+        println!(
+            "- {} -> next_sequence={} rows_emitted={} finished={}",
+            progress.table, progress.next_sequence, progress.rows_emitted, progress.finished
+        );
+    }
+
+    let final_ledger = checkpoint_store.load(&spec.pipeline.name)?;
+    println!(
+        "checkpoint ledger: {} ({} table checkpoint(s))",
+        checkpoint_store.ledger_path(&spec.pipeline.name).display(),
+        final_ledger.tables.len()
+    );
+
+    Ok(())
+}
+
+async fn snapshot_to_minio_staging(
+    file: &str,
+    max_rows_per_table: Option<u64>,
+    endpoint: Option<String>,
+    region: Option<String>,
+    access_key: Option<String>,
+    secret_key: Option<String>,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    ensure_supported_snapshot_source(&spec)?;
+
+    let staging = staging_from_spec(&spec)?;
+    let source = PostgresSource::from_spec(&spec)?;
+    let discovery = source
+        .discover(PostgresDiscoverOptions { tables: vec![] })
+        .await?;
+    let snapshot = source
+        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
+            tables: vec![],
+            max_rows_per_table,
+        })
+        .await?;
+
+    let storage = StagingConfig {
+        kind: StagingKind::Minio,
+        bucket: staging.bucket,
+        prefix: staging.prefix,
+    };
+    let mut config = MinioStagingConfig::from_env(storage.clone())?;
+    if let Some(endpoint) = endpoint {
+        config.endpoint = endpoint;
+    }
+    if let Some(region) = region {
+        config.region = region;
+    }
+    if let Some(access_key) = access_key {
+        config.access_key = access_key;
+    }
+    if let Some(secret_key) = secret_key {
+        config.secret_key = secret_key;
+    }
+
+    let store = MinioStageChunkStore::new(config.clone());
+    store.ensure_ready().await?;
+
+    println!("discovered postgres source: {}", spec.pipeline.name);
+    println!("catalog tables: {}", discovery.catalog.tables.len());
+    println!("minio endpoint: {}", config.endpoint);
+    println!("staging bucket: {}", config.storage.bucket);
+    println!("staged chunks:");
+
+    for table in snapshot.tables {
+        let chunk = store
+            .write_chunk(StageChunkRequest {
+                pipeline_name: spec.pipeline.name.clone(),
+                stream_name: table.table.clone(),
+                partition_key: "default".to_string(),
+                sequence: table.sequence,
+                payload: StageChunkPayload::jsonl_gzip(table.row_count, table.rows_jsonl_gzip),
+            })
+            .await?;
+
+        println!("- {} -> {} rows", table.table, chunk.row_count);
+        println!("  sql: {}", table.sql);
+        println!(
+            "  chunk: s3://{}/{} bytes={}",
+            chunk.bucket, chunk.object_key, chunk.bytes_written
+        );
+    }
+
+    Ok(())
+}
+
+struct ResolvedStaging {
+    bucket: String,
+    prefix: String,
+}
+
+fn ensure_supported_snapshot_source(spec: &AstraSpec) -> anyhow::Result<()> {
+    if spec.source.kind != "postgres" {
+        bail!("snapshot staging currently supports source.kind=postgres only");
+    }
+
+    Ok(())
+}
+
+fn staging_from_spec(spec: &AstraSpec) -> anyhow::Result<ResolvedStaging> {
+    let staging = spec
+        .destination
+        .staging
+        .as_ref()
+        .context("destination.staging is required for snapshot staging")?;
+
+    Ok(ResolvedStaging {
+        bucket: staging.bucket.clone(),
+        prefix: staging.prefix.clone().unwrap_or_default(),
+    })
+}
+
+async fn load_local_staging_to_postgres(
+    file: &str,
+    staging_root: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+
+    let staging = spec
+        .destination
+        .staging
+        .as_ref()
+        .context("destination.staging is required for local destination loading")?;
+    let loader = PostgresDestinationLoader::from_spec(&spec)?;
+    let root_dir = staging_root
+        .or_else(default_staging_root_from_env)
+        .unwrap_or_else(|| PathBuf::from(".astra/staging"));
+    let store = LocalStageChunkStore::new(LocalStagingConfig {
+        root_dir: root_dir.clone(),
+        storage: StagingConfig {
+            kind: StagingKind::Local,
+            bucket: staging.bucket.clone(),
+            prefix: staging.prefix.clone().unwrap_or_default(),
+        },
+    });
+
+    let staged_chunks = store.list_chunks_for_pipeline(&spec.pipeline.name)?;
+    if staged_chunks.is_empty() {
+        bail!(
+            "no staged chunks found for pipeline {} under {}",
+            spec.pipeline.name,
+            root_dir.display()
+        );
+    }
+
+    let mut chunk_payloads = Vec::new();
+    for mut chunk in staged_chunks {
+        let bytes = store.read_chunk(&chunk).await?;
+        chunk.bytes_written = bytes.len() as u64;
+        chunk_payloads.push((chunk, bytes));
+    }
+
+    let report = loader.load_local_stage_chunks(chunk_payloads).await?;
+    println!(
+        "loaded staged chunks into postgres raw schema: {}",
+        report.schema
+    );
+    println!(
+        "destination host: {}:{}",
+        loader.config().host,
+        loader.config().port
+    );
+    println!("local staging root: {}", root_dir.display());
+    for chunk in report.applied_chunks {
+        println!(
+            "- {} -> {} ({})",
+            chunk.object_key,
+            chunk.table_name,
+            if chunk.skipped {
+                "already applied"
+            } else {
+                "applied"
+            }
+        );
+        println!("  rows written: {}", chunk.rows_written);
+    }
+
+    Ok(())
+}
+
+fn default_staging_root_from_env() -> Option<PathBuf> {
+    std::env::var_os("ASTRA_STAGING_LOCAL_ROOT").map(PathBuf::from)

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -344,6 +344,8 @@ async fn snapshot_to_minio_staging(
         .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
             tables: vec![],
             max_rows_per_table,
+            chunk_size: None,
+            start_sequence_by_table: BTreeMap::new(),
         })
         .await?;
 

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -21,7 +21,7 @@ uuid.workspace = true
 thiserror.workspace = true
 async-trait = "0.1"
 sha2 = "0.10"
-tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7", default-features = false, features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 tower-http = { version = "0.5", features = ["fs", "trace"] }
 astra-api = { path = "../../crates/astra-api" }
 astra-core = { path = "../../crates/astra-core" }
@@ -32,5 +32,5 @@ astra-yaml = { path = "../../crates/astra-yaml" }
 
 [dev-dependencies]
 testcontainers = "0.15"
-tokio-postgres = "0.7"
+tokio-postgres = { version = "0.7", default-features = false, features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 serde_yaml.workspace = true


### PR DESCRIPTION
## Summary\nHybrid checkpoint hardening: Postgres control-plane table/API + local fallback resume.\nCLI snapshot cmds wire to API (ASTRA_CONTROL_PLANE_URL), preserve local ledger.\nNew: run_table_progress table, POST/PUT /runs/{run_id}/checkpoints, GET /runs/{run_id}/progress.\nTests/docs updated. Needs libssl-dev for full build/tests.\n\n## Changes\n- apps/control-plane: Postgres repo ext, API routes/handlers, models.\n- apps/cli/src/main.rs: hybrid API/local snapshot cmds.\n- README/issue#39 updates.\n\nCloses #39