### PR TITLE
feat: persist snapshot checkpoints in control-plane metadata (#61)

### DIFF
--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -42,6 +42,10 @@ pub fn routes() -> Router<AppState> {
             "/api/v1/pipeline-runs/:pipeline_run_id/artifacts",
             post(pipelines::record_staged_artifact).get(pipelines::list_staged_artifacts),
         )
+        .route(
+            "/api/v1/pipeline-runs/:pipeline_run_id/table-executions",
+            post(pipelines::upsert_table_execution).get(pipelines::list_table_executions),
+        )
         .route("/api/v1/specs/apply", post(pipelines::apply_spec))
         .route(
             "/api/v1/examples/postgres-to-warehouse",

--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -171,3 +171,32 @@ pub async fn list_staged_artifacts(
         .await?;
     Ok(Json(StagedArtifactsResponse { artifacts }))
 }
+
+pub async fn list_table_executions(
+    State(state): State<AppState>,
+    Path(pipeline_run_id): Path<Uuid>,
+) -> Result<Json<TableExecutionsResponse>, AppError> {
+    let tables = state
+        .pipeline_service
+        .list_table_executions(pipeline_run_id)
+        .await?;
+    Ok(Json(TableExecutionsResponse { tables }))
+}
+
+pub async fn upsert_table_execution(
+    State(state): State<AppState>,
+    Path(pipeline_run_id): Path<Uuid>,
+    Json(request): Json<UpsertTableExecutionRequest>,
+) -> Result<Json<TableExecutionResponse>, AppError> {
+    if request.stream_name.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "stream_name must not be empty".to_string(),
+        ));
+    }
+
+    let response = state
+        .pipeline_service
+        .upsert_table_execution(pipeline_run_id, request)
+        .await?;
+    Ok(Json(response))
+}

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -127,6 +127,10 @@ pub struct TableExecutionResponse {
     pub rows_processed: i64,
     pub rows_total: Option<i64>,
     pub error_summary: Option<String>,
+    pub checkpoint_next_sequence: Option<i64>,
+    pub checkpoint_rows_staged: Option<i64>,
+    pub checkpoint_last_chunk_key: Option<String>,
+    pub checkpoint_completed: bool,
     pub started_at: DateTime<Utc>,
     pub finished_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
@@ -144,6 +148,14 @@ pub struct UpsertTableExecutionRequest {
     pub rows_processed: i64,
     pub rows_total: Option<i64>,
     pub error_summary: Option<String>,
+    #[serde(default)]
+    pub checkpoint_next_sequence: Option<i64>,
+    #[serde(default)]
+    pub checkpoint_rows_staged: Option<i64>,
+    #[serde(default)]
+    pub checkpoint_last_chunk_key: Option<String>,
+    #[serde(default)]
+    pub checkpoint_completed: Option<bool>,
 }
 
 pub enum RunStatus {

--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -303,6 +303,12 @@ impl PipelineRepository for InMemoryPipelineRepository {
             existing.rows_processed = record.rows_processed;
             existing.rows_total = record.rows_total;
             existing.error_summary = record.error_summary;
+            existing.checkpoint_next_sequence = record.checkpoint_next_sequence;
+            existing.checkpoint_rows_staged = record.checkpoint_rows_staged;
+            existing.checkpoint_last_chunk_key = record.checkpoint_last_chunk_key;
+            if let Some(completed) = record.checkpoint_completed {
+                existing.checkpoint_completed = completed;
+            }
             if finished {
                 existing.finished_at = Some(now);
             }
@@ -317,6 +323,10 @@ impl PipelineRepository for InMemoryPipelineRepository {
                 rows_processed: record.rows_processed,
                 rows_total: record.rows_total,
                 error_summary: record.error_summary,
+                checkpoint_next_sequence: record.checkpoint_next_sequence,
+                checkpoint_rows_staged: record.checkpoint_rows_staged,
+                checkpoint_last_chunk_key: record.checkpoint_last_chunk_key,
+                checkpoint_completed: record.checkpoint_completed.unwrap_or(false),
                 started_at: now,
                 finished_at: if finished { Some(now) } else { None },
                 updated_at: now,

--- a/apps/control-plane/src/repositories/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/pipeline_repository.rs
@@ -84,6 +84,10 @@ pub struct TableExecutionRecord {
     pub rows_processed: i64,
     pub rows_total: Option<i64>,
     pub error_summary: Option<String>,
+    pub checkpoint_next_sequence: Option<i64>,
+    pub checkpoint_rows_staged: Option<i64>,
+    pub checkpoint_last_chunk_key: Option<String>,
+    pub checkpoint_completed: bool,
     pub started_at: DateTime<Utc>,
     pub finished_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
@@ -97,6 +101,10 @@ pub struct UpsertTableExecutionRecord {
     pub rows_processed: i64,
     pub rows_total: Option<i64>,
     pub error_summary: Option<String>,
+    pub checkpoint_next_sequence: Option<i64>,
+    pub checkpoint_rows_staged: Option<i64>,
+    pub checkpoint_last_chunk_key: Option<String>,
+    pub checkpoint_completed: Option<bool>,
 }
 
 #[async_trait]

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -115,11 +115,21 @@ impl PostgresPipelineRepository {
                     rows_processed BIGINT NOT NULL DEFAULT 0,
                     rows_total BIGINT,
                     error_summary TEXT,
+                    checkpoint_next_sequence BIGINT,
+                    checkpoint_rows_staged BIGINT,
+                    checkpoint_last_chunk_key TEXT,
+                    checkpoint_completed BOOLEAN NOT NULL DEFAULT FALSE,
                     started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     finished_at TIMESTAMPTZ,
                     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     UNIQUE(pipeline_run_id, stream_name)
                 );
+
+                ALTER TABLE table_executions
+                    ADD COLUMN IF NOT EXISTS checkpoint_next_sequence BIGINT,
+                    ADD COLUMN IF NOT EXISTS checkpoint_rows_staged BIGINT,
+                    ADD COLUMN IF NOT EXISTS checkpoint_last_chunk_key TEXT,
+                    ADD COLUMN IF NOT EXISTS checkpoint_completed BOOLEAN NOT NULL DEFAULT FALSE;
 
                 CREATE INDEX IF NOT EXISTS idx_table_executions_run
                     ON table_executions (pipeline_run_id);
@@ -530,7 +540,9 @@ impl PipelineRepository for PostgresPipelineRepository {
             .query(
                 r#"
                 SELECT id, pipeline_run_id, stream_name, status, rows_processed, rows_total,
-                       error_summary, started_at, finished_at, updated_at
+                       error_summary, checkpoint_next_sequence, checkpoint_rows_staged,
+                       checkpoint_last_chunk_key, checkpoint_completed,
+                       started_at, finished_at, updated_at
                 FROM table_executions
                 WHERE pipeline_run_id = $1
                 ORDER BY stream_name ASC
@@ -556,10 +568,11 @@ impl PipelineRepository for PostgresPipelineRepository {
         let row = client.query_one(
             r#"
             INSERT INTO table_executions (
-                id, pipeline_run_id, stream_name, status, rows_processed, rows_total, error_summary
+                id, pipeline_run_id, stream_name, status, rows_processed, rows_total, error_summary,
+                checkpoint_next_sequence, checkpoint_rows_staged, checkpoint_last_chunk_key, checkpoint_completed
             )
             VALUES (
-                gen_random_uuid(), $1, $2, $3, $4, $5, $6
+                gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, COALESCE($10, FALSE)
             )
             ON CONFLICT (pipeline_run_id, stream_name)
             DO UPDATE SET
@@ -567,10 +580,16 @@ impl PipelineRepository for PostgresPipelineRepository {
                 rows_processed = EXCLUDED.rows_processed,
                 rows_total = EXCLUDED.rows_total,
                 error_summary = EXCLUDED.error_summary,
-                finished_at = CASE WHEN EXCLUDED.status IN ('staged', 'applied', 'failed') THEN NOW() ELSE table_executions.finished_at END,
+                checkpoint_next_sequence = EXCLUDED.checkpoint_next_sequence,
+                checkpoint_rows_staged = EXCLUDED.checkpoint_rows_staged,
+                checkpoint_last_chunk_key = EXCLUDED.checkpoint_last_chunk_key,
+                checkpoint_completed = EXCLUDED.checkpoint_completed,
+                finished_at = CASE WHEN EXCLUDED.status IN ('staged', 'applied', 'failed', 'snapshot_complete') THEN NOW() ELSE table_executions.finished_at END,
                 updated_at = NOW()
             RETURNING id, pipeline_run_id, stream_name, status, rows_processed, rows_total,
-                      error_summary, started_at, finished_at, updated_at
+                      error_summary, checkpoint_next_sequence, checkpoint_rows_staged,
+                      checkpoint_last_chunk_key, checkpoint_completed,
+                      started_at, finished_at, updated_at
             "#,
             &[
                 &record.pipeline_run_id,
@@ -579,6 +598,10 @@ impl PipelineRepository for PostgresPipelineRepository {
                 &record.rows_processed,
                 &record.rows_total,
                 &record.error_summary,
+                &record.checkpoint_next_sequence,
+                &record.checkpoint_rows_staged,
+                &record.checkpoint_last_chunk_key,
+                &record.checkpoint_completed,
             ],
         )
         .await
@@ -597,6 +620,10 @@ fn map_table_execution_row(row: Row) -> TableExecutionRecord {
         rows_processed: row.get("rows_processed"),
         rows_total: row.get("rows_total"),
         error_summary: row.get("error_summary"),
+        checkpoint_next_sequence: row.get("checkpoint_next_sequence"),
+        checkpoint_rows_staged: row.get("checkpoint_rows_staged"),
+        checkpoint_last_chunk_key: row.get("checkpoint_last_chunk_key"),
+        checkpoint_completed: row.get("checkpoint_completed"),
         started_at: row.get("started_at"),
         finished_at: row.get("finished_at"),
         updated_at: row.get("updated_at"),

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -364,7 +364,7 @@ impl PipelineRepository for PostgresPipelineRepository {
                 SELECT $1, p.id, $2, $3, $4, $5
                 FROM pipelines p
                 WHERE p.name = $6
-                RETURNING id, trigger_mode, status, worker_id, started_at, finished_at, created_at, updated_at
+                RETURNING id, $6::text AS pipeline_name, trigger_mode, status, worker_id, started_at, finished_at, created_at, updated_at
                 "#,
                 &[
                     &Uuid::new_v4(),

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -1,12 +1,11 @@
 use crate::{
     models::api::{
         ApplySpecResponse, PipelineRunResponse, PipelineSummaryResponse, Progress,
-        StagedArtifactResponse, TableExecutionResponse, TableExecutionsResponse,
-        UpsertTableExecutionRequest,
+        StagedArtifactResponse, TableExecutionResponse, UpsertTableExecutionRequest,
     },
     repositories::{
         CreatePipelineRunRecord, PipelineRepository, RecordStagedArtifactRecord,
-        TableExecutionRecord, UpsertTableExecutionRecord,
+        UpsertTableExecutionRecord,
     },
 };
 use chrono::Utc;
@@ -252,6 +251,10 @@ impl PipelineService {
                 rows_processed: table.rows_processed,
                 rows_total: table.rows_total,
                 error_summary: table.error_summary,
+                checkpoint_next_sequence: table.checkpoint_next_sequence,
+                checkpoint_rows_staged: table.checkpoint_rows_staged,
+                checkpoint_last_chunk_key: table.checkpoint_last_chunk_key,
+                checkpoint_completed: table.checkpoint_completed,
                 started_at: table.started_at,
                 finished_at: table.finished_at,
                 updated_at: table.updated_at,
@@ -271,6 +274,10 @@ impl PipelineService {
             rows_processed: request.rows_processed,
             rows_total: request.rows_total,
             error_summary: request.error_summary,
+            checkpoint_next_sequence: request.checkpoint_next_sequence,
+            checkpoint_rows_staged: request.checkpoint_rows_staged,
+            checkpoint_last_chunk_key: request.checkpoint_last_chunk_key,
+            checkpoint_completed: request.checkpoint_completed,
         };
         let table = self.repository.upsert_table_execution(record).await?;
         Ok(TableExecutionResponse {
@@ -280,6 +287,10 @@ impl PipelineService {
             rows_processed: table.rows_processed,
             rows_total: table.rows_total,
             error_summary: table.error_summary,
+            checkpoint_next_sequence: table.checkpoint_next_sequence,
+            checkpoint_rows_staged: table.checkpoint_rows_staged,
+            checkpoint_last_chunk_key: table.checkpoint_last_chunk_key,
+            checkpoint_completed: table.checkpoint_completed,
             started_at: table.started_at,
             finished_at: table.finished_at,
             updated_at: table.updated_at,

--- a/apps/control-plane/tests/checkpoint_metadata.rs
+++ b/apps/control-plane/tests/checkpoint_metadata.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use astra_control_plane::{
+    models::api::{TableExecutionResponse, UpsertTableExecutionRequest},
+    services::PipelineService,
+    InMemoryPipelineRepository,
+};
+
+#[tokio::test]
+async fn table_execution_checkpoint_metadata_round_trips_via_service() -> Result<()> {
+    let repository = Arc::new(InMemoryPipelineRepository::default());
+    let service = PipelineService::new(repository);
+
+    let yaml = r#"
+version: v1alpha1
+pipeline:
+  name: test-checkpoint-pipeline
+  mode: snapshot
+  schedule: manual
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.orders
+    snapshot:
+      mode: full
+destination:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+    schema: astra
+  staging:
+    kind: local
+    bucket: astra-staging
+    prefix: test-checkpoint-pipeline/
+  write:
+    mode: append
+runtime:
+  parallelism:
+    tables: 1
+"#;
+
+    service.apply_spec(yaml.to_string(), None).await?;
+    let run = service
+        .create_pipeline_run(
+            "test-checkpoint-pipeline".to_string(),
+            "manual".to_string(),
+            None,
+            None,
+            None,
+        )
+        .await?;
+
+    let table = service
+        .upsert_table_execution(
+            run.id,
+            UpsertTableExecutionRequest {
+                stream_name: "public.orders".to_string(),
+                status: "snapshot_running".to_string(),
+                rows_processed: 42,
+                rows_total: Some(100),
+                error_summary: None,
+                checkpoint_next_sequence: Some(2),
+                checkpoint_rows_staged: Some(42),
+                checkpoint_last_chunk_key: Some(
+                    "pipelines/test/streams/public.orders/chunks/00000000000000000001.jsonl.gz"
+                        .to_string(),
+                ),
+                checkpoint_completed: Some(false),
+            },
+        )
+        .await?;
+
+    assert_eq!(table.checkpoint_next_sequence, Some(2));
+    assert_eq!(table.checkpoint_rows_staged, Some(42));
+    assert_eq!(
+        table.checkpoint_last_chunk_key.as_deref(),
+        Some("pipelines/test/streams/public.orders/chunks/00000000000000000001.jsonl.gz")
+    );
+    assert!(!table.checkpoint_completed);
+
+    let updated = service
+        .upsert_table_execution(
+            run.id,
+            UpsertTableExecutionRequest {
+                stream_name: "public.orders".to_string(),
+                status: "snapshot_complete".to_string(),
+                rows_processed: 100,
+                rows_total: Some(100),
+                error_summary: None,
+                checkpoint_next_sequence: Some(3),
+                checkpoint_rows_staged: Some(100),
+                checkpoint_last_chunk_key: Some(
+                    "pipelines/test/streams/public.orders/chunks/00000000000000000002.jsonl.gz"
+                        .to_string(),
+                ),
+                checkpoint_completed: Some(true),
+            },
+        )
+        .await?;
+
+    assert_eq!(updated.status, "snapshot_complete");
+    assert_eq!(updated.checkpoint_next_sequence, Some(3));
+    assert_eq!(updated.checkpoint_rows_staged, Some(100));
+    assert!(updated.checkpoint_completed);
+
+    let tables: Vec<TableExecutionResponse> = service.list_table_executions(run.id).await?;
+    assert_eq!(tables.len(), 1);
+    assert_eq!(tables[0].stream_name, "public.orders");
+    assert_eq!(tables[0].checkpoint_next_sequence, Some(3));
+    assert_eq!(tables[0].checkpoint_rows_staged, Some(100));
+    assert!(tables[0].checkpoint_completed);
+
+    Ok(())
+}

--- a/apps/control-plane/tests/pg-persistence.rs
+++ b/apps/control-plane/tests/pg-persistence.rs
@@ -115,10 +115,23 @@ version: 1.0
         rows_processed: 0i64,
         rows_total: Some(100i64),
         error_summary: None,
+        checkpoint_next_sequence: Some(1),
+        checkpoint_rows_staged: Some(42),
+        checkpoint_last_chunk_key: Some(
+            "pipelines/test/streams/test_stream/chunks/00000000000000000000.jsonl.gz".to_string(),
+        ),
+        checkpoint_completed: Some(false),
     };
     let table_exec = repo2.upsert_table_execution(upsert_rec).await?;
     assert_eq!(table_exec.status, "running");
     assert_eq!(table_exec.rows_processed, 0i64);
+    assert_eq!(table_exec.checkpoint_next_sequence, Some(1));
+    assert_eq!(table_exec.checkpoint_rows_staged, Some(42));
+    assert_eq!(
+        table_exec.checkpoint_last_chunk_key.as_deref(),
+        Some("pipelines/test/streams/test_stream/chunks/00000000000000000000.jsonl.gz")
+    );
+    assert!(!table_exec.checkpoint_completed);
 
     let execs = repo2.list_table_executions(run_id).await?;
     assert_eq!(execs.len(), 1);
@@ -126,25 +139,42 @@ version: 1.0
     let upsert_rec_terminal = UpsertTableExecutionRecord {
         pipeline_run_id: run_id,
         stream_name: "test_stream".to_string(),
-        status: "failed".to_string(),
+        status: "snapshot_complete".to_string(),
         rows_processed: 50i64,
         rows_total: Some(100i64),
-        error_summary: Some("test error message".to_string()),
+        error_summary: None,
+        checkpoint_next_sequence: Some(2),
+        checkpoint_rows_staged: Some(100),
+        checkpoint_last_chunk_key: Some(
+            "pipelines/test/streams/test_stream/chunks/00000000000000000001.jsonl.gz".to_string(),
+        ),
+        checkpoint_completed: Some(true),
     };
     let table_exec_terminal = repo2.upsert_table_execution(upsert_rec_terminal).await?;
-    assert_eq!(table_exec_terminal.status, "failed");
+    assert_eq!(table_exec_terminal.status, "snapshot_complete");
     assert!(table_exec_terminal.finished_at.is_some());
+    assert_eq!(table_exec_terminal.error_summary, None);
+    assert_eq!(table_exec_terminal.checkpoint_next_sequence, Some(2));
+    assert_eq!(table_exec_terminal.checkpoint_rows_staged, Some(100));
     assert_eq!(
-        table_exec_terminal.error_summary,
-        Some("test error message".to_string())
+        table_exec_terminal.checkpoint_last_chunk_key.as_deref(),
+        Some("pipelines/test/streams/test_stream/chunks/00000000000000000001.jsonl.gz")
     );
+    assert!(table_exec_terminal.checkpoint_completed);
 
     // Verify table exec persistence
     drop(repo2);
     let repo3 = PostgresPipelineRepository::connect(&pg_url).await?;
     let execs3 = repo3.list_table_executions(run_id).await?;
     assert_eq!(execs3.len(), 1);
-    assert_eq!(execs3[0].status, "failed");
+    assert_eq!(execs3[0].status, "snapshot_complete");
+    assert_eq!(execs3[0].checkpoint_next_sequence, Some(2));
+    assert_eq!(execs3[0].checkpoint_rows_staged, Some(100));
+    assert_eq!(
+        execs3[0].checkpoint_last_chunk_key.as_deref(),
+        Some("pipelines/test/streams/test_stream/chunks/00000000000000000001.jsonl.gz")
+    );
+    assert!(execs3[0].checkpoint_completed);
 
     // Test cancelled run status
     let now = Utc::now();

--- a/apps/control-plane/tests/pg-persistence.rs
+++ b/apps/control-plane/tests/pg-persistence.rs
@@ -7,36 +7,65 @@ use astra_control_plane::repositories::{
 use astra_yaml::AstraSpec;
 use chrono::Utc;
 use serde_json::json;
-use testcontainers::runners::AsyncRunner;
-use testcontainers_modules::postgres::Postgres;
-use uuid::Uuid;
+use testcontainers::{core::RunnableImage, core::WaitFor, runners::AsyncRunner, GenericImage};
 
 #[tokio::test]
 async fn test_pg_repo_full_flow() -> Result<()> {
-    let postgres_image = Postgres::default();
-    let node = postgres_image.start().await?;
-    let pg_url = format!(
-        "postgres://postgres:postgres@localhost:{}",
-        node.get_host_port_ipv4(5432).await?
-    );
+    let postgres_image = RunnableImage::from(
+        GenericImage::new("postgres", "15")
+            .with_env_var("POSTGRES_PASSWORD", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            )),
+    )
+    .with_mapped_port((55432, 5432));
+    let _node = postgres_image.start().await?;
+    let pg_url = "postgres://postgres:postgres@localhost:55432".to_string();
 
     // First repo instance
     let repo1 = PostgresPipelineRepository::connect(&pg_url).await?;
 
-    let pipeline_name = format!("test-pg-{}", Uuid::new_v4());
+    let pipeline_name = "test-pipeline".to_string();
 
     let spec_yaml = r#"
+version: v1alpha1
 pipeline:
   name: test-pipeline
+  mode: snapshot
+  schedule: manual
 source:
   kind: postgres
-  config:
-    connection_string: postgres://foo
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.orders
+    snapshot:
+      mode: full
 destination:
-  kind: s3
-  config:
-    bucket: bar
-version: 1.0
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+    schema: astra
+  staging:
+    kind: local
+    bucket: astra-staging
+    prefix: test-pipeline/
+  write:
+    mode: append
+runtime:
+  parallelism:
+    tables: 1
 "#;
     let spec: AstraSpec = serde_yaml::from_str(spec_yaml).context("parse spec")?;
     let raw_yaml = spec_yaml.to_string();
@@ -198,25 +227,60 @@ version: 1.0
 
 #[tokio::test]
 async fn test_pg_repo_list_pipelines() -> Result<()> {
-    let postgres_image = Postgres::default();
-    let node = postgres_image.start().await?;
-    let pg_url = format!(
-        "postgres://postgres:postgres@localhost:{}",
-        node.get_host_port_ipv4(5432).await?
-    );
+    let postgres_image = RunnableImage::from(
+        GenericImage::new("postgres", "15")
+            .with_env_var("POSTGRES_PASSWORD", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            )),
+    )
+    .with_mapped_port((55433, 5432));
+    let _node = postgres_image.start().await?;
+    let pg_url = "postgres://postgres:postgres@localhost:55433".to_string();
 
     let repo = PostgresPipelineRepository::connect(&pg_url).await?;
 
-    let pipeline_name = format!("test-list-{}", Uuid::new_v4());
+    let pipeline_name = "test-list-pipeline".to_string();
 
     let spec_yaml = r#"
+version: v1alpha1
 pipeline:
   name: test-list-pipeline
+  mode: snapshot
+  schedule: manual
 source:
   kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.orders
+    snapshot:
+      mode: full
 destination:
-  kind: s3
-version: 1.0
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:POSTGRES_PASSWORD
+    schema: astra
+  staging:
+    kind: local
+    bucket: astra-staging
+    prefix: test-list-pipeline/
+  write:
+    mode: append
+runtime:
+  parallelism:
+    tables: 1
 "#;
     let spec: AstraSpec = serde_yaml::from_str(spec_yaml)?;
     let raw_yaml = spec_yaml.to_string();


### PR DESCRIPTION
## Summary
- persist snapshot checkpoint metadata alongside table execution progress in control-plane storage
- expose checkpoint/progress fields through stable service and HTTP API shapes
- add local smoke coverage for checkpoint metadata round-tripping through the control-plane service
- extend Postgres persistence coverage to assert checkpoint fields survive repository reconnects

## What changed
- extended `TableExecutionRecord` / `UpsertTableExecutionRecord` with checkpoint metadata:
  - `checkpoint_next_sequence`
  - `checkpoint_rows_staged`
  - `checkpoint_last_chunk_key`
  - `checkpoint_completed`
- updated the Postgres repository schema/upsert/list logic to persist those fields
- updated the in-memory repository to track the same fields
- updated service/API response/request types to expose checkpoint state
- added table execution HTTP handlers/routes:
  - `GET /api/v1/pipeline-runs/:pipeline_run_id/table-executions`
  - `POST /api/v1/pipeline-runs/:pipeline_run_id/table-executions`
- updated the Postgres persistence test to verify checkpoint metadata survives reconnects
- added a non-Docker smoke test for service-level checkpoint metadata round-tripping

## Validation
- `cargo test -p astra-control-plane --test checkpoint_metadata` ✅
- `cargo check -p astra-control-plane` ✅
- `cargo test -p astra-control-plane --test pg-persistence -- --nocapture` ⚠️ compiles, but cannot run in this environment because Docker is not reachable (`client error (Connect)` when creating test containers)

Closes #61.
