### PR TITLE
feat: add a single local snapshot execution command (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-postgres-ra
 cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml
 ```
 
+If you want one boring command that runs that same local happy path end to end, use:
+
+```bash
+export POSTGRES_PASSWORD=...
+export WAREHOUSE_PASSWORD=...
+export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
+export ASTRA_CHECKPOINT_LOCAL_ROOT=.astra/checkpoints
+cargo run -p astra -- execute-local-snapshot examples/postgres-to-postgres-raw.astra.yaml --max-rows-per-table 1000
+```
+
+`execute-local-snapshot` is intentionally narrow and honest: it orchestrates the existing `snapshot-to-local-staging` and `load-local-staging-to-postgres` commands, prints stage-level progress, and currently supports the local Postgres-source to Postgres-destination slice only.
+
 The loader reads staged `JSONL.gz` chunks and lands them in raw Postgres tables (default schema `astra_raw`) with one `jsonb` payload column plus loader metadata. It also records applied chunk object keys so reruns skip already-loaded chunks instead of duplicating them like idiots.
 
 If you want the same flow against a local MinIO bucket instead of the filesystem, bring up the Podman Compose stack and run:

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -54,6 +54,22 @@ pub enum Command {
         #[arg(long)]
         control_plane_url: Option<String>,
     },
+    /// Run the narrow local snapshot happy path end to end: snapshot -> local staging -> Postgres load
+    ExecuteLocalSnapshot {
+        file: String,
+        #[arg(long)]
+        max_rows_per_table: Option<u64>,
+        #[arg(long)]
+        staging_root: Option<PathBuf>,
+        #[arg(long)]
+        checkpoint_root: Option<PathBuf>,
+        #[arg(long)]
+        chunk_size: Option<u64>,
+        #[arg(long)]
+        no_resume: bool,
+        #[arg(long)]
+        control_plane_url: Option<String>,
+    },
 }
 
 #[cfg(test)]
@@ -138,6 +154,39 @@ mod tests {
                 file: "examples/postgres-to-postgres-raw.astra.yaml".to_string(),
                 staging_root: Some(PathBuf::from("/tmp/astra/staging")),
                 control_plane_url: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_execute_local_snapshot_flags() {
+        let cli = Cli::parse_from([
+            "astra",
+            "execute-local-snapshot",
+            "examples/postgres-to-postgres-raw.astra.yaml",
+            "--max-rows-per-table",
+            "100",
+            "--staging-root",
+            "/tmp/astra/staging",
+            "--checkpoint-root",
+            "/tmp/astra/checkpoints",
+            "--chunk-size",
+            "50",
+            "--no-resume",
+            "--control-plane-url",
+            "http://127.0.0.1:8080",
+        ]);
+
+        assert_eq!(
+            cli.command,
+            Command::ExecuteLocalSnapshot {
+                file: "examples/postgres-to-postgres-raw.astra.yaml".to_string(),
+                max_rows_per_table: Some(100),
+                staging_root: Some(PathBuf::from("/tmp/astra/staging")),
+                checkpoint_root: Some(PathBuf::from("/tmp/astra/checkpoints")),
+                chunk_size: Some(50),
+                no_resume: true,
+                control_plane_url: Some("http://127.0.0.1:8080".to_string()),
             }
         );
     }

--- a/apps/cli/src/commands.rs
+++ b/apps/cli/src/commands.rs
@@ -401,6 +401,45 @@ pub async fn snapshot_to_minio_staging(
     Ok(())
 }
 
+pub async fn execute_local_snapshot(
+    file: &str,
+    max_rows_per_table: Option<u64>,
+    staging_root: Option<PathBuf>,
+    checkpoint_root: Option<PathBuf>,
+    chunk_size: Option<u64>,
+    no_resume: bool,
+    control_plane_url: Option<String>,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+    ensure_cdc_runtime_not_requested(&spec, "execute-local-snapshot")?;
+    ensure_supported_snapshot_source(&spec)?;
+    ensure_supported_local_snapshot_destination(&spec)?;
+
+    println!("local snapshot execution: {}", spec.pipeline.name);
+    println!("stage 1/2: snapshot -> local staging");
+    snapshot_to_local_staging(
+        file,
+        max_rows_per_table,
+        staging_root.clone(),
+        checkpoint_root,
+        chunk_size,
+        no_resume,
+        control_plane_url.clone(),
+    )
+    .await?;
+
+    println!("stage 2/2: local staging -> postgres");
+    load_local_staging_to_postgres(file, staging_root, control_plane_url).await?;
+
+    println!(
+        "local snapshot execution complete: {} (snapshot -> local staging -> postgres)",
+        spec.pipeline.name
+    );
+
+    Ok(())
+}
+
 pub async fn load_local_staging_to_postgres(
     file: &str,
     staging_root: Option<PathBuf>,
@@ -538,6 +577,20 @@ fn ensure_cdc_runtime_not_requested(spec: &AstraSpec, command: &str) -> anyhow::
 fn ensure_supported_snapshot_source(spec: &AstraSpec) -> anyhow::Result<()> {
     if spec.source.kind != "postgres" {
         bail!("snapshot staging currently supports source.kind=postgres only");
+    }
+
+    Ok(())
+}
+
+fn ensure_supported_local_snapshot_destination(spec: &AstraSpec) -> anyhow::Result<()> {
+    if spec.destination.kind != "postgres" {
+        bail!(
+            "execute-local-snapshot currently supports destination.kind=postgres only because the end-to-end local loader is the Postgres raw loader"
+        );
+    }
+
+    if spec.destination.staging.is_none() {
+        bail!("execute-local-snapshot requires destination.staging for the local staging handoff");
     }
 
     Ok(())
@@ -885,5 +938,48 @@ runtime: {}
         assert!(options.tables.is_empty());
         assert!(no_tables_remaining(&spec, false, &options));
         assert!(!no_tables_remaining(&spec, true, &options));
+    }
+
+    #[test]
+    fn execute_local_snapshot_rejects_non_postgres_destination() {
+        let spec = AstraSpec::parse_yaml(
+            r#"
+version: v1alpha1
+pipeline:
+  name: postgres-to-snowflake
+  mode: snapshot
+  schedule: manual
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
+  capture:
+    tables:
+      - public.users
+    snapshot:
+      mode: full
+      chunkSize: 1000
+destination:
+  kind: snowflake
+  staging:
+    kind: s3
+    bucket: astra-staging
+  write:
+    mode: merge
+runtime: {}
+"#,
+        )
+        .expect("spec parses");
+
+        let error = ensure_supported_local_snapshot_destination(&spec)
+            .expect_err("non-postgres destination should be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("execute-local-snapshot currently supports destination.kind=postgres only"));
     }
 }

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -57,5 +57,25 @@ async fn dispatch(command: Command) -> anyhow::Result<()> {
             staging_root,
             control_plane_url,
         } => commands::load_local_staging_to_postgres(&file, staging_root, control_plane_url).await,
+        Command::ExecuteLocalSnapshot {
+            file,
+            max_rows_per_table,
+            staging_root,
+            checkpoint_root,
+            chunk_size,
+            no_resume,
+            control_plane_url,
+        } => {
+            commands::execute_local_snapshot(
+                &file,
+                max_rows_per_table,
+                staging_root,
+                checkpoint_root,
+                chunk_size,
+                no_resume,
+                control_plane_url,
+            )
+            .await
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a single local end-to-end snapshot execution command to the Astra CLI
- keep the implementation intentionally narrow and honest
- orchestrate the existing snapshot-to-local-staging and load-local-staging-to-postgres flows instead of duplicating business logic

## What changed
- added `execute-local-snapshot` CLI command
- wired command dispatch in the CLI library
- added guardrails so this command currently supports the local Postgres-source -> Postgres-destination slice only
- documented the new happy-path command in the README
- added tests for parsing and destination validation

## Why this is the right slice
This command is intentionally boring: it runs the already-existing local happy path end to end.
That makes local execution easier to use and gives us a better base for the larger compose-backed smoke work in #64.

## Validation
- `cargo test -p astra -- --nocapture` ✅
- `cargo run -p astra -- execute-local-snapshot --help` ✅
- branch CI ✅

Closes #40.
