### PR TITLE
docs: add CLAUDE.md and fix stale CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Astra
+
+Astra is a self-hostable data replication platform (v0.1) — a Rust-first alternative to Airbyte/Fivetran for database CDC and bulk snapshot replication. Pipelines are defined in YAML (`v1alpha1` spec) and executed via CLI or control-plane API.
+
+## Commands
+
+### Rust (workspace root)
+```bash
+cargo build                    # build all crates
+cargo test --workspace         # test all crates
+cargo test -p <crate>          # test a single crate
+cargo test <test_name>         # run a specific test by name
+cargo clippy --workspace       # lint
+```
+
+### Control plane
+```bash
+cargo run -p astra-control-plane                          # in-memory mode
+ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra cargo run -p astra-control-plane
+```
+
+### CLI
+```bash
+cargo run -p astra -- validate examples/postgres-to-warehouse.astra.yaml
+cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
+cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml
+cargo run -p astra -- execute-local-snapshot examples/postgres-to-warehouse.astra.yaml
+```
+
+### Web app (`apps/web`)
+```bash
+npm install && npm run dev     # Vite dev server at 127.0.0.1:4173
+npm run build
+npm run lint                   # TypeScript type check
+```
+
+### Local infrastructure
+```bash
+podman compose -f deploy/docker-compose/docker-compose.yml up -d   # starts Postgres + MinIO
+```
+
+### Python smoke test
+```bash
+python3 scripts/yaml_contract_smoke.py
+```
+
+## Architecture
+
+**Modular monolith** (see `docs/decisions/adr-0001-modular-monolith.md`): single control-plane binary with clean internal boundaries, Postgres for metadata, S3/MinIO for durable staging.
+
+### Workspace layout
+
+| Path | Purpose |
+|------|---------|
+| `apps/control-plane` | Axum HTTP API + scheduler + metadata manager |
+| `apps/cli` | Clap CLI — validate, discover, snapshot, load |
+| `apps/web` | React 18 + TypeScript + Vite frontend |
+| `crates/astra-yaml` | YAML spec parsing/validation (`v1alpha1`) |
+| `crates/astra-metadata` | Shared enums/types (PipelineStatus, JobKind, RunPhase…) |
+| `crates/astra-runtime` | Staging abstraction — local, S3, MinIO; chunked JSONL.gz |
+| `crates/astra-connectors` | Postgres source (snapshot + discovery) + destination (raw load) |
+| `crates/astra-cdc` | CDC orchestration (stub) |
+| `deploy/docker-compose` | Local Postgres + MinIO stack |
+
+### Request / data flow
+
+1. **Spec ingestion** — YAML parsed by `astra-yaml`, validated, registered via `PipelineService`
+2. **Repository layer** — `PipelineRepository` trait with two impls: `PostgresPipelineRepository` (persistent) and `InMemoryPipelineRepository` (dev fallback)
+3. **Control plane REST API** — `/api/v1/pipelines`, `/api/v1/pipeline-runs`, `/api/v1/specs/apply`; web UI served from the same binary
+4. **Snapshot execution** — CLI calls Postgres connector to paginate rows → `astra-runtime` stages JSONL.gz chunks → destination connector loads raw tables (`astra_raw` schema)
+5. **Checkpointing** — `astra-runtime` persists a ledger of staged chunks; CLI `--no-resume` restarts from scratch
+
+### Key design patterns
+
+- **Service/Repository**: `PipelineService` is the only entry point to state; callers never touch the repo directly
+- **Trait-based storage backends**: swap Postgres ↔ in-memory without changing service code
+- **Spec-as-data**: YAML spec is parsed once, serialised to JSON, and shared across CLI, API, and UI
+- **Staging contract** (`docs/architecture/staging-contract.md`): local/S3/MinIO share the same `StageChunk` metadata schema
+- **Resumable workflows**: checkpoint ledger tracks processed chunks; snapshot can resume mid-run
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ASTRA_CONTROL_PLANE_ADDR` | `127.0.0.1:8080` | Bind address |
+| `ASTRA_DATABASE_URL` | _(none — in-memory)_ | Postgres metadata DB |
+| `ASTRA_S3_ENDPOINT` | — | MinIO/S3 endpoint |
+| `ASTRA_S3_REGION` | `us-east-1` | |
+| `ASTRA_S3_ACCESS_KEY` / `ASTRA_S3_SECRET_KEY` | — | S3 credentials |
+| `ASTRA_STAGING_LOCAL_ROOT` | — | Local staging dir |
+| `ASTRA_CHECKPOINT_LOCAL_ROOT` | — | Checkpoint ledger dir |
+| `POSTGRES_PASSWORD` | — | Source Postgres password |
+
+See `.env.example` for a full reference.
+
+### What is and isn't implemented (v0.1)
+
+**Working**: YAML validation, Postgres schema discovery, local snapshot → JSONL.gz staging with resumption, MinIO staging, raw Postgres loading, control-plane API + web UI, in-memory and Postgres-backed persistence.
+
+**Stubbed / not yet implemented**: CDC execution (returns explicit error), Python connector runtime, secrets management beyond `env:KEY`, observability, worker pool, schema evolution, multi-table parallelism.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ cargo run -p astra-control-plane
 - `cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000` — snapshots Postgres tables to local filesystem staging (requires reachable Postgres, set `POSTGRES_PASSWORD`)
 - `cargo run -p astra -- snapshot-to-minio-staging examples/postgres-to-postgres-raw.astra.yaml` — snapshots to MinIO staging (requires reachable Postgres and MinIO)
 - `cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml` — loads staged chunks into a raw Postgres destination (requires staged data and reachable destination Postgres)
+- `cargo run -p astra -- execute-local-snapshot examples/postgres-to-postgres-raw.astra.yaml` — end-to-end local snapshot: stages rows to local filesystem, then loads into the Postgres destination in one command (requires reachable source and destination Postgres, set `POSTGRES_PASSWORD`)
 - Control plane pipeline list/apply API at `http://127.0.0.1:8080`
 - Web UI pipeline inventory and YAML editor at `http://127.0.0.1:8080`
 - YAML contract smoke test: `python3 scripts/yaml_contract_smoke.py`
@@ -84,7 +85,6 @@ cargo run -p astra-control-plane
 
 ### Not yet implemented
 - CDC execution (explicitly rejected with a clear error message)
-- Single end-to-end orchestration command (individual steps exist, no unified command yet)
 - Run history / execution status in the web UI
 - Python connector runtime
 - Observability / structured diagnostics


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` — guidance for Claude Code with build/test/lint commands, workspace layout table, request/data flow narrative, key design patterns, environment variables, and v0.1 implementation status
- Fix `CONTRIBUTING.md` — add `execute-local-snapshot` to the working flows list (shipped in #40 but missing from docs), remove stale "not yet implemented" entry for the end-to-end orchestration command

## Test plan
- [ ] Verify `CLAUDE.md` commands match current repo behavior (`cargo build`, `cargo test --workspace`, etc.)
- [ ] Verify `execute-local-snapshot` entry in CONTRIBUTING.md is accurate against the CLI implementation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)