### PR TITLE
feat: render pipeline run history in the web UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,29 @@ type PipelinesResponse = {
   pipelines: Pipeline[];
 };
 
+type PipelineRun = {
+  id: string;
+  pipeline_name: string;
+  trigger_mode: string;
+  status: string;
+  worker_id: string | null;
+  started_at: string;
+  finished_at: string | null;
+  created_at: string;
+  updated_at: string;
+  stats_json: Record<string, unknown> | null;
+};
+
+type PipelineRunsResponse = {
+  runs: PipelineRun[];
+};
+
+type RunHistoryState = {
+  loading: boolean;
+  error: string | null;
+  runs: PipelineRun[];
+};
+
 type ApplySpecResponse = {
   pipeline_name: string;
   spec_version: number;
@@ -49,6 +72,31 @@ const ONBOARDING_STEPS = [
 
 const DEFAULT_AUTHOR = 'web-ui';
 
+function runStatusClass(status: string): string {
+  const s = status.toLowerCase();
+  if (s === 'succeeded') return 'status-pill--success';
+  if (s === 'failed' || s === 'error') return 'status-pill--error';
+  if (s === 'running') return 'status-pill--running';
+  return 'status-pill--muted';
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (!finishedAt) return '—';
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+function formatTimestamp(ts: string): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
 export function App() {
   const [activeView, setActiveView] = useState<ViewKey>('overview');
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
@@ -58,6 +106,8 @@ export function App() {
   const [yamlStatus, setYamlStatus] = useState<string>('Loading canonical example…');
   const [applyStatus, setApplyStatus] = useState<string>('');
   const [refreshToken, setRefreshToken] = useState(0);
+  const [expandedPipelines, setExpandedPipelines] = useState<Set<string>>(new Set());
+  const [runHistories, setRunHistories] = useState<Record<string, RunHistoryState>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -131,6 +181,47 @@ export function App() {
     const activeCount = pipelines.filter((pipeline) => pipeline.status.toLowerCase() === 'active').length;
     return `${pipelines.length} pipeline${pipelines.length === 1 ? '' : 's'} tracked, ${activeCount} active.`;
   }, [pipelines]);
+
+  async function fetchRunHistory(pipelineName: string) {
+    setRunHistories((prev) => ({
+      ...prev,
+      [pipelineName]: { loading: true, error: null, runs: prev[pipelineName]?.runs ?? [] }
+    }));
+
+    try {
+      const response = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/run-history`);
+      if (!response.ok) {
+        throw new Error(`Run history request failed: ${response.status}`);
+      }
+      const data = (await response.json()) as PipelineRunsResponse;
+      setRunHistories((prev) => ({
+        ...prev,
+        [pipelineName]: { loading: false, error: null, runs: data.runs }
+      }));
+    } catch (error) {
+      setRunHistories((prev) => ({
+        ...prev,
+        [pipelineName]: {
+          loading: false,
+          error: error instanceof Error ? error.message : 'Failed to load run history.',
+          runs: []
+        }
+      }));
+    }
+  }
+
+  function handleToggleRuns(pipelineName: string) {
+    setExpandedPipelines((prev) => {
+      const next = new Set(prev);
+      if (next.has(pipelineName)) {
+        next.delete(pipelineName);
+      } else {
+        next.add(pipelineName);
+        void fetchRunHistory(pipelineName);
+      }
+      return next;
+    });
+  }
 
   async function handleApplyYaml() {
     setApplyStatus('Applying YAML spec…');
@@ -276,20 +367,68 @@ export function App() {
               <p className="muted">No pipelines yet. Apply a YAML spec and this stops looking abandoned.</p>
             ) : (
               <div className="list">
-                {pipelines.map((pipeline) => (
-                  <article key={`${pipeline.name}-${pipeline.spec_version}`} className="list-row">
-                    <div>
-                      <h3>{pipeline.name}</h3>
-                      <p className="muted">
-                        {pipeline.source_kind} → {pipeline.destination_kind}
-                      </p>
-                    </div>
-                    <div className="list-row__meta">
-                      <span className="status-pill">{pipeline.status}</span>
-                      <span className="muted">v{pipeline.spec_version}</span>
-                    </div>
-                  </article>
-                ))}
+                {pipelines.map((pipeline) => {
+                  const isExpanded = expandedPipelines.has(pipeline.name);
+                  const history = runHistories[pipeline.name];
+
+                  return (
+                    <article key={`${pipeline.name}-${pipeline.spec_version}`} className="list-row">
+                      <div className="list-row__header">
+                        <div>
+                          <h3>{pipeline.name}</h3>
+                          <p className="muted">
+                            {pipeline.source_kind} → {pipeline.destination_kind}
+                          </p>
+                        </div>
+                        <div className="list-row__meta">
+                          <span className="status-pill">{pipeline.status}</span>
+                          <span className="muted">v{pipeline.spec_version}</span>
+                          <button
+                            type="button"
+                            className="secondary-button run-toggle-btn"
+                            onClick={() => handleToggleRuns(pipeline.name)}
+                            aria-expanded={isExpanded}
+                          >
+                            {isExpanded ? 'Hide runs' : 'View runs'}
+                          </button>
+                        </div>
+                      </div>
+
+                      {isExpanded && (
+                        <div className="run-history">
+                          {!history || history.loading ? (
+                            <p className="muted run-history__status">Loading run history…</p>
+                          ) : history.error ? (
+                            <p className="error-text run-history__status">{history.error}</p>
+                          ) : history.runs.length === 0 ? (
+                            <p className="muted run-history__status">No runs yet for this pipeline.</p>
+                          ) : (
+                            <div className="run-history__list">
+                              <div className="run-history__header-row">
+                                <span>Run ID</span>
+                                <span>Status</span>
+                                <span>Trigger</span>
+                                <span>Started</span>
+                                <span>Duration</span>
+                              </div>
+                              {history.runs.map((run) => (
+                                <div key={run.id} className="run-history__row">
+                                  <span className="run-history__id">{run.id.slice(0, 8)}</span>
+                                  <span>
+                                    <span className={`status-pill ${runStatusClass(run.status)}`}>{run.status}</span>
+                                  </span>
+                                  <span className="muted">{run.trigger_mode}</span>
+                                  <span className="muted">{formatTimestamp(run.started_at)}</span>
+                                  <span className="muted">{formatDuration(run.started_at, run.finished_at)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
               </div>
             )}
           </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -203,7 +203,7 @@ button:active {
 
 .section-heading,
 .action-row,
-.list-row,
+.list-row__header,
 .list-row__meta {
   display: flex;
   align-items: center;
@@ -223,6 +223,10 @@ button:active {
 }
 
 .list-row {
+  padding: 0;
+}
+
+.list-row__header {
   padding: 1rem 1.25rem;
 }
 
@@ -260,6 +264,77 @@ button:active {
   color: #9bf0c5;
 }
 
+.status-pill--success {
+  background: rgba(56, 201, 133, 0.14);
+  border-color: rgba(56, 201, 133, 0.3);
+  color: #9bf0c5;
+}
+
+.status-pill--error {
+  background: rgba(255, 100, 100, 0.14);
+  border-color: rgba(255, 100, 100, 0.3);
+  color: #ffb4b4;
+}
+
+.status-pill--running {
+  background: rgba(91, 124, 255, 0.28);
+  border-color: rgba(120, 149, 255, 0.5);
+  color: #d9e1ff;
+}
+
+.run-toggle-btn {
+  font-size: 0.78rem;
+  padding: 0.4rem 0.75rem;
+  white-space: nowrap;
+}
+
+.run-history {
+  border-top: 1px solid rgba(128, 146, 219, 0.15);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.run-history__status {
+  margin: 0;
+}
+
+.run-history__list {
+  display: grid;
+  gap: 0;
+}
+
+.run-history__header-row,
+.run-history__row {
+  display: grid;
+  grid-template-columns: 6rem 1fr 1fr 1fr 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.45rem 0;
+  font-size: 0.85rem;
+}
+
+.run-history__header-row {
+  color: #8ea2ff;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid rgba(128, 146, 219, 0.15);
+  padding-bottom: 0.6rem;
+  margin-bottom: 0.1rem;
+}
+
+.run-history__row + .run-history__row {
+  border-top: 1px solid rgba(128, 146, 219, 0.08);
+}
+
+.run-history__id {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, monospace;
+  font-size: 0.78rem;
+  color: #b8c4f4;
+}
+
 @media (max-width: 960px) {
   .shell {
     grid-template-columns: 1fr;
@@ -278,9 +353,19 @@ button:active {
   .hero,
   .section-heading,
   .action-row,
-  .list-row,
+  .list-row__header,
   .list-row__meta {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .run-history__header-row,
+  .run-history__row {
+    grid-template-columns: 5rem 1fr 1fr;
+  }
+
+  .run-history__header-row span:nth-child(n+4),
+  .run-history__row span:nth-child(n+4) {
+    display: none;
   }
 }

--- a/scripts/yaml_contract_smoke.py
+++ b/scripts/yaml_contract_smoke.py
@@ -131,6 +131,37 @@ def main():
         if "postgres-analytics" not in names:
             raise SmokeFailure(f"applied pipeline missing from list response: {pipelines_payload}")
 
+        _, create_run_body = http_request(
+            "/api/v1/pipeline-runs",
+            method="POST",
+            json_body={"pipeline_name": "postgres-analytics", "trigger_mode": "manual"},
+            expected_status=200,
+        )
+        created_run = json.loads(create_run_body)
+        for field in ("id", "pipeline_name", "trigger_mode", "status", "started_at", "created_at", "updated_at"):
+            if field not in created_run:
+                raise SmokeFailure(f"created run missing field '{field}': {created_run}")
+        if created_run["pipeline_name"] != "postgres-analytics":
+            raise SmokeFailure(f"created run has wrong pipeline_name: {created_run}")
+        if created_run["trigger_mode"] != "manual":
+            raise SmokeFailure(f"created run has wrong trigger_mode: {created_run}")
+
+        _, history_body = http_request(
+            "/api/v1/pipelines/postgres-analytics/run-history",
+            expected_status=200,
+        )
+        history_payload = json.loads(history_body)
+        if "runs" not in history_payload:
+            raise SmokeFailure(f"run-history response missing 'runs' key: {history_payload}")
+        if len(history_payload["runs"]) == 0:
+            raise SmokeFailure("run-history returned empty list after creating a run")
+        latest_run = history_payload["runs"][0]
+        for field in ("id", "pipeline_name", "trigger_mode", "status", "started_at", "created_at", "updated_at"):
+            if field not in latest_run:
+                raise SmokeFailure(f"run-history entry missing field '{field}': {latest_run}")
+        if latest_run["pipeline_name"] != "postgres-analytics":
+            raise SmokeFailure(f"run-history entry has wrong pipeline_name: {latest_run}")
+
         _, invalid_apply_body = http_request(
             "/api/v1/specs/apply",
             method="POST",
@@ -152,6 +183,11 @@ def main():
             "/api/v1/examples/postgres-to-warehouse",
             "/api/v1/specs/apply",
             "Canonical example loaded from examples/postgres-to-warehouse.astra.yaml",
+            "/api/v1/pipelines/",
+            "run-history",
+            "No runs yet for this pipeline",
+            "Loading run history",
+            "View runs",
         ):
             if marker not in bundle:
                 raise SmokeFailure(f"web bundle no longer contains required UI contract marker: {marker}")


### PR DESCRIPTION
## Summary

Closes #71.

- Adds an expandable **View runs** panel to each pipeline card in the Job status view
- Fetches run history from `GET /api/v1/pipelines/:name/run-history` on expand; collapses cleanly on re-click
- Handles all operator states: loading, empty ("No runs yet"), error, and success
- Each run entry shows: short run ID, status pill (with success/error/running colour variants), trigger mode, started timestamp, and duration
- Mobile-responsive: collapses to 3 columns on narrow screens, hiding started/duration

## Test plan

- [x] TypeScript type-check (`tsc --noEmit`) passes with zero errors
- [x] Vite production build succeeds
- [x] `yaml_contract_smoke.py` extended to: create a pipeline run via `POST /api/v1/pipeline-runs`, call `GET /api/v1/pipelines/postgres-analytics/run-history`, validate response shape (all required fields present), and assert new UI contract markers in the built bundle
- [x] Full smoke test passes end-to-end against the in-memory control-plane

🤖 Generated with [Claude Code](https://claude.com/claude-code)