### PR TITLE
feat: render table-level progress and error summaries in the web UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,29 @@ type ApplySpecResponse = {
   message: string;
 };
 
+type TableExecution = {
+  id: string;
+  stream_name: string;
+  status: string;
+  rows_processed: number;
+  rows_total: number | null;
+  error_summary: string | null;
+  checkpoint_completed: boolean;
+  started_at: string;
+  finished_at: string | null;
+  updated_at: string;
+};
+
+type TableExecutionsResponse = {
+  tables: TableExecution[];
+};
+
+type TableExecutionState = {
+  loading: boolean;
+  error: string | null;
+  tables: TableExecution[];
+};
+
 const NAV_ITEMS: Array<{ key: ViewKey; label: string; eyebrow: string }> = [
   { key: 'overview', label: 'Overview', eyebrow: 'Control plane' },
   { key: 'onboarding', label: 'Onboarding', eyebrow: 'Source → destination' },
@@ -80,6 +103,21 @@ function runStatusClass(status: string): string {
   return 'status-pill--muted';
 }
 
+function tableStatusClass(status: string): string {
+  const s = status.toLowerCase();
+  if (s === 'applied') return 'status-pill--success';
+  if (s === 'failed') return 'status-pill--error';
+  if (s === 'snapshot') return 'status-pill--running';
+  return 'status-pill--muted'; // staged, queued, etc.
+}
+
+function formatRowProgress(rowsProcessed: number, rowsTotal: number | null): string {
+  if (rowsTotal != null) {
+    return `${rowsProcessed.toLocaleString()} / ${rowsTotal.toLocaleString()} rows`;
+  }
+  return `${rowsProcessed.toLocaleString()} rows`;
+}
+
 function formatDuration(startedAt: string, finishedAt: string | null): string {
   if (!finishedAt) return '—';
   const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
@@ -108,6 +146,8 @@ export function App() {
   const [refreshToken, setRefreshToken] = useState(0);
   const [expandedPipelines, setExpandedPipelines] = useState<Set<string>>(new Set());
   const [runHistories, setRunHistories] = useState<Record<string, RunHistoryState>>({});
+  const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
+  const [tableExecutions, setTableExecutions] = useState<Record<string, TableExecutionState>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -208,6 +248,46 @@ export function App() {
         }
       }));
     }
+  }
+
+  async function fetchTableExecutions(runId: string) {
+    setTableExecutions((prev) => ({
+      ...prev,
+      [runId]: { loading: true, error: null, tables: prev[runId]?.tables ?? [] }
+    }));
+    try {
+      const response = await fetch(`/api/v1/pipeline-runs/${encodeURIComponent(runId)}/table-executions`);
+      if (!response.ok) {
+        throw new Error(`Table executions request failed: ${response.status}`);
+      }
+      const data = (await response.json()) as TableExecutionsResponse;
+      setTableExecutions((prev) => ({
+        ...prev,
+        [runId]: { loading: false, error: null, tables: data.tables }
+      }));
+    } catch (error) {
+      setTableExecutions((prev) => ({
+        ...prev,
+        [runId]: {
+          loading: false,
+          error: error instanceof Error ? error.message : 'Failed to load table executions.',
+          tables: []
+        }
+      }));
+    }
+  }
+
+  function handleToggleTables(runId: string) {
+    setExpandedRuns((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) {
+        next.delete(runId);
+      } else {
+        next.add(runId);
+        void fetchTableExecutions(runId);
+      }
+      return next;
+    });
   }
 
   function handleToggleRuns(pipelineName: string) {
@@ -410,18 +490,75 @@ export function App() {
                                 <span>Trigger</span>
                                 <span>Started</span>
                                 <span>Duration</span>
+                                <span></span>
                               </div>
-                              {history.runs.map((run) => (
-                                <div key={run.id} className="run-history__row">
-                                  <span className="run-history__id">{run.id.slice(0, 8)}</span>
-                                  <span>
-                                    <span className={`status-pill ${runStatusClass(run.status)}`}>{run.status}</span>
-                                  </span>
-                                  <span className="muted">{run.trigger_mode}</span>
-                                  <span className="muted">{formatTimestamp(run.started_at)}</span>
-                                  <span className="muted">{formatDuration(run.started_at, run.finished_at)}</span>
-                                </div>
-                              ))}
+                              {history.runs.map((run) => {
+                                const isRunExpanded = expandedRuns.has(run.id);
+                                const tableState = tableExecutions[run.id];
+                                return (
+                                  <div key={run.id} className="run-history__item">
+                                    <div className="run-history__row">
+                                      <span className="run-history__id">{run.id.slice(0, 8)}</span>
+                                      <span>
+                                        <span className={`status-pill ${runStatusClass(run.status)}`}>{run.status}</span>
+                                      </span>
+                                      <span className="muted">{run.trigger_mode}</span>
+                                      <span className="muted">{formatTimestamp(run.started_at)}</span>
+                                      <span className="muted">{formatDuration(run.started_at, run.finished_at)}</span>
+                                      <span>
+                                        <button
+                                          type="button"
+                                          className="secondary-button table-toggle-btn"
+                                          onClick={() => handleToggleTables(run.id)}
+                                          aria-expanded={isRunExpanded}
+                                        >
+                                          {isRunExpanded ? 'Hide tables' : 'Tables'}
+                                        </button>
+                                      </span>
+                                    </div>
+
+                                    {isRunExpanded && (
+                                      <div className="table-executions">
+                                        {!tableState || tableState.loading ? (
+                                          <p className="muted table-executions__status">Loading table executions…</p>
+                                        ) : tableState.error ? (
+                                          <p className="error-text table-executions__status">{tableState.error}</p>
+                                        ) : tableState.tables.length === 0 ? (
+                                          <p className="muted table-executions__status">No table executions recorded for this run.</p>
+                                        ) : (
+                                          <div className="table-executions__list">
+                                            <div className="table-executions__header-row">
+                                              <span>Stream</span>
+                                              <span>Status</span>
+                                              <span>Progress</span>
+                                              <span>Error</span>
+                                            </div>
+                                            {tableState.tables.map((table) => (
+                                              <div key={table.id} className="table-executions__row">
+                                                <span className="table-executions__name">{table.stream_name}</span>
+                                                <span>
+                                                  <span className={`status-pill ${tableStatusClass(table.status)}`}>
+                                                    {table.status}
+                                                  </span>
+                                                </span>
+                                                <span className="muted">
+                                                  {formatRowProgress(table.rows_processed, table.rows_total)}
+                                                </span>
+                                                <span
+                                                  className={table.error_summary ? 'table-executions__error' : 'muted'}
+                                                  title={table.error_summary ?? undefined}
+                                                >
+                                                  {table.error_summary ?? '—'}
+                                                </span>
+                                              </div>
+                                            ))}
+                                          </div>
+                                        )}
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
                             </div>
                           )}
                         </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -307,7 +307,7 @@ button:active {
 .run-history__header-row,
 .run-history__row {
   display: grid;
-  grid-template-columns: 6rem 1fr 1fr 1fr 1fr;
+  grid-template-columns: 6rem 1fr 1fr 1fr 1fr auto;
   gap: 0.5rem;
   align-items: center;
   padding: 0.45rem 0;
@@ -325,7 +325,7 @@ button:active {
   margin-bottom: 0.1rem;
 }
 
-.run-history__row + .run-history__row {
+.run-history__item + .run-history__item {
   border-top: 1px solid rgba(128, 146, 219, 0.08);
 }
 
@@ -333,6 +333,70 @@ button:active {
   font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, monospace;
   font-size: 0.78rem;
   color: #b8c4f4;
+}
+
+.table-toggle-btn {
+  font-size: 0.72rem;
+  padding: 0.3rem 0.6rem;
+  white-space: nowrap;
+}
+
+.table-executions {
+  border-top: 1px solid rgba(128, 146, 219, 0.1);
+  margin: 0 0.25rem 0.5rem;
+  padding: 0.75rem 0.5rem 0.25rem;
+  background: rgba(8, 14, 28, 0.4);
+  border-radius: 0 0 12px 12px;
+}
+
+.table-executions__status {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.table-executions__list {
+  display: grid;
+  gap: 0;
+}
+
+.table-executions__header-row,
+.table-executions__row {
+  display: grid;
+  grid-template-columns: 2fr auto 9rem 2fr;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.4rem 0.25rem;
+  font-size: 0.82rem;
+}
+
+.table-executions__header-row {
+  color: #8ea2ff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid rgba(128, 146, 219, 0.12);
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.1rem;
+}
+
+.table-executions__row + .table-executions__row {
+  border-top: 1px solid rgba(128, 146, 219, 0.06);
+}
+
+.table-executions__name {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, monospace;
+  font-size: 0.78rem;
+  color: #b8c4f4;
+}
+
+.table-executions__error {
+  font-size: 0.78rem;
+  color: #ffb4b4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: default;
 }
 
 @media (max-width: 960px) {
@@ -361,11 +425,25 @@ button:active {
 
   .run-history__header-row,
   .run-history__row {
-    grid-template-columns: 5rem 1fr 1fr;
+    grid-template-columns: 5rem 1fr auto;
   }
 
   .run-history__header-row span:nth-child(n+4),
   .run-history__row span:nth-child(n+4) {
+    display: none;
+  }
+
+  .run-history__row span:last-child {
+    display: flex;
+  }
+
+  .table-executions__header-row,
+  .table-executions__row {
+    grid-template-columns: 1fr auto 1fr;
+  }
+
+  .table-executions__header-row span:last-child,
+  .table-executions__row span:last-child {
     display: none;
   }
 }


### PR DESCRIPTION
Closes #72

## Summary

- Adds a per-run **Tables** toggle in the job status run history rows, fetching `GET /api/v1/pipeline-runs/:id/table-executions` on first expand
- Renders a nested table drill-down showing **stream name**, **status pill**, **row progress** (`processed / total rows`), and **error summary** (truncated with full text on hover) for each table execution
- Handles all states cleanly: loading spinner text, fetch errors, empty (no executions recorded), and populated data
- Status colours follow existing design system: `snapshot` → running (blue), `applied` → success (green), `failed` → error (red), `staged` → muted

## Changes

- `apps/web/src/App.tsx` — types (`TableExecution`, `TableExecutionsResponse`, `TableExecutionState`), `fetchTableExecutions`, `handleToggleTables`, `tableStatusClass`, `formatRowProgress`, updated run-row JSX
- `apps/web/src/styles.css` — `.table-executions` panel and grid styles, `.table-toggle-btn`, updated run-history grid to 6 columns, responsive rules

## Test plan

- [ ] Start the control plane (`cargo run -p astra-control-plane`) and web dev server (`npm run dev` in `apps/web`)
- [ ] Apply a pipeline spec and trigger a run; verify **Tables** button appears on each run row
- [ ] Click **Tables** on a run with recorded table executions — confirm stream name, status, row counts, and any error summaries render correctly
- [ ] Click **Tables** on a run with no table executions — confirm "No table executions recorded" empty state
- [ ] Confirm loading and error states behave sensibly (e.g. kill the control plane mid-request)
- [ ] Verify **Hide tables** collapses the panel
- [ ] `npm run lint` passes (TypeScript strict mode)
- [ ] `npm run build` produces a clean production bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)