### PR TITLE
docs: flesh out v0.1-SCOPE.md and fix stale DEMO-CHECKLIST.md

### DIFF
--- a/docs/DEMO-CHECKLIST.md
+++ b/docs/DEMO-CHECKLIST.md
@@ -12,10 +12,10 @@ Verify end-to-end flow: bootstrap → spec → run → UI/API verification.
 
 ## 2. Quickstart Snapshot Flow (CLI)
 
-- [ ] `cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000`
-- [ ] Verify staging: `ls -la .astra/staging/` (JSONL.gz chunks)
-- [ ] `cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml`
-- [ ] Verify loaded: Query raw tables in warehouse Postgres (`astra_raw` schema)
+- [ ] Seed fixture tables (see CONTRIBUTING.md quickstart for SQL)
+- [ ] `ASTRA_SMOKE_PG_PASSWORD=astra cargo run -p astra -- execute-local-snapshot examples/smoke-local-snapshot.astra.yaml --control-plane-url http://127.0.0.1:8080`
+- [ ] Verify destination row counts: `psql postgres://astra:astra@localhost:5432/astra -c "SELECT COUNT(*) FROM astra_raw.raw_public_smoke_users;"` (expect 20)
+- [ ] Verify destination row counts: `psql postgres://astra:astra@localhost:5432/astra -c "SELECT COUNT(*) FROM astra_raw.raw_public_smoke_orders;"` (expect 50)
 
 ## 3. Control Plane + UI
 
@@ -27,13 +27,15 @@ Verify end-to-end flow: bootstrap → spec → run → UI/API verification.
 
 ## 4. API Verification
 
-- [ ] `curl http://127.0.0.1:8080/api/pipelines` (list)
-- [ ] `curl http://127.0.0.1:8080/api/pipelines/{id}/runs` (history)
-- [ ] Latest run shows snapshot progress/stages
+- [ ] `curl http://127.0.0.1:8080/api/v1/pipelines` (list pipelines)
+- [ ] `curl http://127.0.0.1:8080/api/v1/pipelines/smoke-local-snapshot/run-history` (run history)
+- [ ] `curl http://127.0.0.1:8080/api/v1/pipeline-runs/<run-id>/table-executions` (per-table status and row counts)
 
 ## Known Limitations (v0.1)
 
-- CDC not executable (source skeleton only)
-- No worker orchestration (manual CLI runs)
-- Local staging only (MinIO adapter available but unproven)
-- UI is foundation (job history WIP)
+- CDC not executable — returns an explicit error if attempted
+- No worker orchestration — pipelines are triggered manually via CLI
+- Append-only destination writes — no merge or upsert semantics
+- `execute-local-snapshot` requires `destination.kind: postgres`
+
+See [docs/v0.1-SCOPE.md](./v0.1-SCOPE.md) for the full limitations list.

--- a/docs/v0.1-SCOPE.md
+++ b/docs/v0.1-SCOPE.md
@@ -1,27 +1,148 @@
 # Astra v0.1 Scope and Known Limitations
 
-## In Scope
+This document describes what shipped in Astra v0.1, what is explicitly out of scope, and what is deferred to future milestones. It is intended to give operators and contributors an honest picture of the system before deploying or building on it.
 
-- Snapshot-only Postgres → Postgres/Snowflake
-- Control-plane APIs
-- Local worker
-- Web UI basics
-- No CDC
+---
 
-## Known Limitations
+## What shipped in v0.1
 
-- No CDC execution
-- No schema evolution
-- Local-only staging
-- No distributed workers
-- UI WIP
+### Pipeline spec
 
-## Future Work
+- YAML pipeline spec (`v1alpha1`) — parsing, validation, and schema-level error reporting
+- Spec is parsed once, stored as JSON in the control plane, and shared across CLI, API, and UI
+- `validate` CLI command rejects malformed specs with structured errors before any execution
 
-- CDC
-- Destinations
-- Cloud deploy
-- etc.
+### Postgres source
 
-See [release checklists (#67)](https://github.com/Astra-core/Astra/issues/67),
-[quickstart (#69)](https://github.com/Astra-core/Astra/issues/69).
+- Schema discovery (`discover-source`) — enumerates tables, column types, and primary keys
+- Full snapshot with paginated chunking — configurable `chunkSize` per table
+- Incremental snapshot mode flag is parsed and stored but behaves identically to full in v0.1
+- Source connection via host/port/database/username with `env:KEY` password reference
+
+### Staging
+
+- Local filesystem staging — rows written as JSONL.gz chunks under a configurable root directory
+- MinIO/S3 staging — same chunk format and metadata schema, S3-compatible endpoint
+- Staging contract is stable: `StageChunk` metadata (stream name, partition key, sequence, byte count, row count, schema fingerprint) is consistent across backends
+
+### Postgres destination (raw loader)
+
+- Loads staged JSONL.gz chunks into a `astra_raw` schema on the destination Postgres
+- Table naming: `raw_<schema>_<table>` (e.g. `public.smoke_users` → `astra_raw.raw_public_smoke_users`)
+- Write mode: append only — no deduplication or merge logic in v0.1
+- Idempotent chunk application — a completed chunk is tracked in `astra_raw._applied_chunks` and skipped on rerun
+
+### Resumable execution
+
+- Checkpoint ledger persists which chunks have been staged; interrupted snapshots resume from the last unfinished chunk
+- `--no-resume` flag forces a full restart, discarding the checkpoint ledger
+- Checkpoint state is stored on local filesystem; control-plane-backed checkpointing uses the metadata DB when `ASTRA_DATABASE_URL` is set
+
+### CLI commands
+
+| Command | What it does |
+|---------|-------------|
+| `validate` | Parse and validate a YAML spec; exit non-zero on any error |
+| `discover-source` | Connect to Postgres and print discovered schema as a snapshot skeleton |
+| `snapshot-to-local-staging` | Snapshot Postgres tables to local JSONL.gz chunks |
+| `snapshot-to-minio-staging` | Snapshot Postgres tables to MinIO/S3 chunks |
+| `load-local-staging-to-postgres` | Load locally staged chunks into Postgres raw destination |
+| `execute-local-snapshot` | End-to-end: snapshot → local staging → Postgres load in one command |
+
+### Control-plane API
+
+All endpoints are under `/api/v1/`.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /pipelines` | List registered pipelines |
+| `GET /pipelines/:name` | Get pipeline YAML spec |
+| `POST /specs/apply` | Register or update a pipeline spec |
+| `GET /pipelines/:name/runs` | List runs for a pipeline |
+| `GET /pipelines/:name/latest-run` | Latest run summary |
+| `GET /pipelines/:name/run-history` | Paginated run history |
+| `POST /pipeline-runs` | Create a run record |
+| `POST /pipeline-runs/:id/status` | Update run status and progress |
+| `GET /pipeline-runs/:id/table-executions` | Per-table execution status and row counts |
+| `POST /pipeline-runs/:id/table-executions` | Record or update a table execution |
+| `GET /pipeline-runs/:id/artifacts` | List staged artifacts for a run |
+| `POST /pipeline-runs/:id/artifacts` | Record a staged artifact |
+
+### Web UI
+
+- Pipeline inventory — name, source/destination kind, status, spec version
+- Run history per pipeline — run ID, status, trigger mode, start time, duration
+- Table-level drill-down per run — stream name, status, rows processed / rows total, error summary
+- YAML studio — load the canonical example spec, edit, and apply via the API
+- All state is backend-grounded; the UI renders no invented data
+
+### Persistence
+
+- **In-memory** (default, no config required) — suitable for local development; state is lost on restart
+- **Postgres-backed** — set `ASTRA_DATABASE_URL`; pipeline, run, table execution, and artifact records are durable
+
+### Automated testing
+
+- Unit and integration tests across all crates (`cargo test --workspace`)
+- Postgres integration tests for the repository layer (`cargo test -p astra-control-plane`)
+- End-to-end snapshot smoke test (`python3 scripts/e2e_snapshot_smoke.py`) — seeds fixtures, runs execute-local-snapshot, verifies destination row counts, and validates idempotent rerun behavior
+
+---
+
+## Known limitations
+
+### CDC is not implemented
+
+CDC execution is explicitly unsupported and returns a clear error if attempted. The source connector has a CDC stub that is wired to return `Err("CDC not implemented")`. This is by design for v0.1. CDC tailing semantics are a post-v0.1 milestone.
+
+### execute-local-snapshot requires a Postgres destination
+
+The `execute-local-snapshot` command only supports `destination.kind: postgres`. The `examples/postgres-to-warehouse.astra.yaml` spec targets Snowflake and will be rejected with an explicit error. Use `examples/smoke-local-snapshot.astra.yaml` for local end-to-end validation.
+
+### Append-only destination writes
+
+The Postgres raw loader appends rows; there is no merge, upsert, or deduplication logic. Re-running a pipeline without `--no-resume` skips already-applied chunks (idempotent), but the raw tables will contain duplicate rows if the source data changed between runs.
+
+### Sequential table processing
+
+Multi-table parallelism (`runtime.parallelism.tables`) is parsed and stored but not enforced in v0.1. Tables are processed sequentially.
+
+### Schema evolution is not enforced
+
+`schemaEvolution.additiveChanges` and `schemaEvolution.breakingChanges` config keys are parsed and stored but have no runtime effect in v0.1. Schema changes in the source are not detected or acted on.
+
+### Secrets via environment variables only
+
+The only supported `passwordRef` format is `env:KEY`. Vault, AWS Secrets Manager, GCP Secret Manager, and other secret backends are not supported.
+
+### Single local worker
+
+There is no worker pool, scheduler, or distributed execution in v0.1. Pipelines are run manually via the CLI. The control-plane scheduler field in the spec is stored but not acted on.
+
+### Python connector runtime not implemented
+
+Python-based connectors are not supported. The connector interface is Rust-only in v0.1.
+
+### No structured observability
+
+There are no structured logs, metrics endpoints, or tracing hooks in v0.1. Execution output is printed to stdout. Operators cannot yet diagnose failures without reading raw output.
+
+### UI onboarding is a placeholder
+
+The onboarding wizard in the web UI renders placeholder cards. Pipeline creation requires a YAML spec applied via the YAML studio or the `POST /api/v1/specs/apply` endpoint directly.
+
+---
+
+## Post-v0.1 roadmap
+
+The following are explicitly deferred and out of scope for v0.1:
+
+- **CDC tailing** — incremental replication from Postgres logical replication slots
+- **Merge/upsert destination semantics** — SCD2, deduplication, primary-key merge
+- **Additional destinations** — Snowflake, BigQuery, Redshift, DuckDB
+- **Python connector runtime** — subprocess-based connector protocol for community/SaaS connectors
+- **Distributed worker pool** — multiple workers, work queues, failure recovery
+- **Schema evolution enforcement** — detect and handle additive and breaking source schema changes
+- **Observability** — structured logging, Prometheus metrics, OpenTelemetry tracing
+- **Secrets management** — Vault, cloud secret stores, encrypted credential references
+- **UI onboarding wizard** — guided pipeline creation flow with real form inputs and validation


### PR DESCRIPTION
Closes #9 (together with #69 / #89 already merged)

## Summary

- **`docs/v0.1-SCOPE.md`** — replaces the thin placeholder doc (bullet lists with "etc.") with a full, accurate account of what shipped in v0.1: pipeline spec, Postgres source, staging backends, raw loader, resumable checkpointing, all CLI commands, full API surface, web UI surfaces, persistence modes, and automated testing. Known limitations are documented precisely (no CDC, Postgres-destination-only for execute-local-snapshot, append-only writes, sequential table processing, env-only secrets, no observability, stub onboarding UI). The "Future Work" section now lists an explicit post-v0.1 roadmap instead of "etc."

- **`docs/DEMO-CHECKLIST.md`** — fixes stale content: updates the quickstart step to use `execute-local-snapshot` with the smoke spec, corrects API paths from `/api/*` to `/api/v1/*`, adds the table-executions verification step, and replaces the WIP known-limitations bullet with accurate ones linked to the scope doc.

## Test plan

- [ ] Read `docs/v0.1-SCOPE.md` end to end — verify every "shipped" claim matches actual code behaviour
- [ ] Follow the DEMO-CHECKLIST.md steps on a clean local stack and confirm all steps pass
- [ ] Verify API paths in the checklist (`/api/v1/pipelines`, `/api/v1/pipeline-runs/:id/table-executions`) return expected responses from a running control plane

🤖 Generated with [Claude Code](https://claude.com/claude-code)