### PR TITLE
chore: v0.1 release readiness — CI tests, README quickstart, CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
         run: cargo fmt --all --check
       - name: Check Rust workspace buildability
         run: cargo check --workspace
+      - name: Lint with Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+  rust-tests:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run workspace tests
+        run: cargo test --workspace
 
   web-foundation:
     name: Web foundation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to Astra are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+---
+
+## [0.1.0] - 2026-04-01
+
+First public release of Astra. One complete vertical slice: Postgres snapshot → local/MinIO staging → Postgres raw destination, with a control plane API and web UI for visibility.
+
+### Added
+
+#### Pipeline spec
+- `v1alpha1` YAML pipeline spec — parsing, validation, and structured error reporting
+- `validate` CLI command — rejects malformed specs before any execution
+- Spec stored as JSON in the control plane and shared across CLI, API, and UI
+
+#### Postgres source
+- `discover-source` — enumerates tables, column types, and primary keys
+- Full snapshot with paginated chunking; configurable `chunkSize` per table
+- Resumable execution — checkpoint ledger tracks processed chunks; interrupted snapshots resume from the last unfinished chunk
+- `--no-resume` flag to force a full restart
+
+#### Staging
+- Local filesystem staging — rows written as JSONL.gz chunks
+- MinIO/S3 staging — same chunk format and metadata schema via S3-compatible adapter
+- Stable staging contract: `StageChunk` metadata (stream name, partition key, sequence, byte count, row count, schema fingerprint) consistent across backends
+
+#### Postgres destination (raw loader)
+- Loads staged JSONL.gz chunks into an `astra_raw` schema on the destination Postgres
+- Table naming: `raw_<schema>_<table>` (e.g. `astra_raw.raw_public_smoke_users`)
+- Idempotent chunk application — completed chunks tracked in `astra_raw._applied_chunks` and skipped on rerun
+
+#### CLI commands
+- `snapshot-to-local-staging` — snapshot Postgres tables to local JSONL.gz chunks
+- `snapshot-to-minio-staging` — snapshot to MinIO/S3 chunks
+- `load-local-staging-to-postgres` — load staged chunks into Postgres raw destination
+- `execute-local-snapshot` — end-to-end: snapshot → local staging → Postgres load in one command
+
+#### Control-plane API
+- `GET /api/v1/pipelines` — list registered pipelines
+- `POST /api/v1/specs/apply` — register or update a pipeline spec
+- `GET /api/v1/pipelines/:name/runs` — list runs for a pipeline
+- `GET /api/v1/pipelines/:name/latest-run` — latest run summary
+- `GET /api/v1/pipelines/:name/run-history` — paginated run history
+- `POST /api/v1/pipeline-runs` — create a run record
+- `POST /api/v1/pipeline-runs/:id/status` — update run status and progress
+- `GET /api/v1/pipeline-runs/:id/table-executions` — per-table execution status and row counts
+- `POST /api/v1/pipeline-runs/:id/artifacts` — record a staged artifact
+
+#### Web UI
+- Pipeline inventory — name, source/destination kind, status, spec version
+- Run history per pipeline — run ID, status, trigger mode, start time, duration
+- Table-level drill-down per run — stream name, status, rows processed / rows total, error summary
+- YAML studio — load, edit, and apply a pipeline spec via the API
+- Onboarding wizard — 4-step guided pipeline creation flow
+- Built with React 18 + TypeScript + Vite; served by the control-plane binary
+
+#### Persistence
+- In-memory (default) — suitable for local development; no config required
+- Postgres-backed — set `ASTRA_DATABASE_URL`; pipeline, run, table execution, and artifact records are durable
+
+#### Testing
+- Unit and integration tests across all crates (`cargo test --workspace`)
+- Postgres repository integration tests
+- End-to-end snapshot smoke test (`python3 scripts/e2e_snapshot_smoke.py`) — seeds fixtures, runs `execute-local-snapshot`, verifies destination row counts, validates idempotent rerun
+
+### Known limitations
+
+See [`docs/v0.1-SCOPE.md`](docs/v0.1-SCOPE.md) for the full list. Key ones:
+
+- **CDC not implemented** — returns an explicit error if attempted
+- **Append-only destination writes** — no merge, upsert, or deduplication
+- **Sequential table processing** — multi-table parallelism parsed but not enforced
+- **Secrets via environment variables only** — `env:KEY` is the only supported `passwordRef` format
+- **No structured observability** — execution output to stdout only
+- **Single local worker** — no scheduler or distributed execution; pipelines triggered manually via CLI

--- a/README.md
+++ b/README.md
@@ -1,208 +1,135 @@
 # Astra
 
-Astra is an open-source data replication platform aiming to be the easy, fast alternative to Airbyte and the self-hostable answer to Fivetran.
+Astra is a self-hostable data replication platform — a Rust-first alternative to Airbyte/Fivetran for database CDC and bulk snapshot replication. Pipelines are defined in YAML and executed via CLI or control-plane API.
 
-## Product goals
+## Quickstart
 
-- **Blazing fast pipelines** for database CDC and bulk replication
-- **Stupidly easy onboarding** through both UI flows and declarative YAML
-- **Easy self-hosting** with a sane Podman Compose path
-- **Cloud-ready architecture** without forcing cloud complexity onto local installs
+### Prerequisites
 
-## v0.1 priorities
+- [Rust](https://rustup.rs) (stable)
+- [Node.js](https://nodejs.org) 20+
+- [Podman](https://podman.io) + `podman-compose` (or Docker Compose)
+- Python 3.9+ (for smoke tests)
 
-Astra v0.1 focuses on one real vertical slice:
-- configure a source and destination
-- run an initial snapshot/backfill
-- continue with incremental sync later; CDC is not executable yet in the current Postgres source skeleton
-- view job history and status in the UI
-- manage the same config via YAML
-
-## Proposed architecture
-
-- Rust-first modular monolith for the control plane
-- Postgres for metadata/state/checkpoints
-- Object storage for durable staging/replay
-- High-performance DB CDC lane
-- Python runtime for long-tail SaaS/community connectors
-
-See the docs folder for the real details instead of README cosplay.
-
-## Docs
-
-- Product brief: `docs/product/brief.md`
-- Architecture RFC: `docs/architecture/rfc-0001-v1-architecture.md`
-- YAML spec draft: `docs/architecture/yaml-spec-draft.md`
-- Staging contract draft: `docs/architecture/staging-contract.md`
-- Example pipeline config: `examples/postgres-to-warehouse.astra.yaml`
-- End-to-end YAML contract smoke test: `python3 scripts/yaml_contract_smoke.py`
-- Kanban + epics + issue seed: `docs/product/kanban-and-issue-seed.md`
-- v0.1 roadmap: `docs/product/v0.1-roadmap.md`
-- ADR: `docs/decisions/adr-0001-modular-monolith.md`
-
-## Local development stack
-
-Astra includes a minimal local dependency stack at `deploy/docker-compose/docker-compose.yml`.
-
-Start it with:
+### 1. Start the local stack
 
 ```bash
 podman compose -f deploy/docker-compose/docker-compose.yml up -d
 ```
 
-Stop it with:
+This starts Postgres (`:5432`) and MinIO (`:9000` API, `:9001` console).
+
+### 2. Build
 
 ```bash
-podman compose -f deploy/docker-compose/docker-compose.yml down
+cargo build
+cd apps/web && npm install && npm run build && cd ../..
 ```
 
-Default local ports:
-- Postgres metadata/state: `5432`
-- MinIO S3 API: `9000`
-- MinIO console: `9001`
-
-For local-first staging without a live object store, the runtime crate now includes a filesystem-backed adapter that preserves the same bucket/object-key layout used by MinIO/S3. See `docs/architecture/staging-contract.md` and `.env.example` for the current local staging knobs.
-
-## Suggested repo layout
-
-```text
-apps/
-  control-plane/
-  web/
-  worker/
-  cli/
-crates/
-  astra-core/
-  astra-runtime/
-  astra-metadata/
-  astra-connectors/
-  astra-cdc/
-  astra-saas-sdk/
-  astra-python-runtime/
-  astra-yaml/
-  astra-api/
-  astra-observability/
-  astra-secrets/
-connectors/
-  rust/
-  python/
-docs/
-deploy/
-```
-
-## Immediate next steps
-
-1. Finalize the YAML spec and metadata model
-2. Build the control plane skeleton
-3. Implement the first Postgres CDC path
-4. Add object-storage staging and one destination loader
-5. Add UI onboarding and job history
-
-## Running the current web app foundation
-
-The React + TypeScript web app foundation lives in `apps/web`.
-
-For backend-only work, run the control plane from the repo root:
+### 3. Start the control plane
 
 ```bash
-cargo run -p astra-control-plane
+ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra \
+  cargo run -p astra-control-plane
 ```
 
-For frontend development, run the control plane in one terminal, then in `apps/web/` run:
+Open [http://127.0.0.1:8080](http://127.0.0.1:8080) for the web UI.
 
-```bash
-npm install
-npm run dev
+### 4. Seed fixture data
+
+```sql
+-- connect: psql postgres://astra:astra@localhost:5432/astra
+CREATE TABLE IF NOT EXISTS public.smoke_users (
+  id SERIAL PRIMARY KEY, name TEXT, email TEXT
+);
+CREATE TABLE IF NOT EXISTS public.smoke_orders (
+  id SERIAL PRIMARY KEY, user_id INT, amount NUMERIC
+);
+INSERT INTO public.smoke_users (name, email)
+  SELECT 'user_' || i, 'user_' || i || '@example.com'
+  FROM generate_series(1, 20) AS i;
+INSERT INTO public.smoke_orders (user_id, amount)
+  SELECT (random() * 19 + 1)::int, (random() * 1000)::numeric(10,2)
+  FROM generate_series(1, 50);
 ```
 
-Open <http://127.0.0.1:4173> for the Vite dev server.
-
-For a self-hosted frontend build served by the Rust control plane, in `apps/web/` run:
+### 5. Run an end-to-end snapshot
 
 ```bash
-npm install
-npm run build
-```
-
-Then open <http://127.0.0.1:8080> after starting `cargo run -p astra-control-plane`.
-
-If `ASTRA_DATABASE_URL` points at a reachable Postgres instance, the control plane now persists applied pipeline specs and pipeline summaries there. If not, it falls back to in-memory storage so local hacking still works instead of faceplanting.
-
-For the self-hosted Postgres source skeleton, start the local stack with Podman Compose, export the source password if your YAML uses `passwordRef: env:POSTGRES_PASSWORD`, then run:
-
-```bash
-export POSTGRES_PASSWORD=astra
-cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
-```
-
-That currently does the minimum useful thing: parse and validate the Postgres source config, inspect table schemas from a reachable Postgres instance, and emit a snapshot-oriented SQL plan for the captured tables.
-
-CDC is still not executable in this skeleton. If a spec uses `pipeline.mode: cdc` or `source.capture.cdc`, `astra apply` and the control-plane apply API now reject it instead of pretending the runtime exists.
-
-There is also a first honest execution slice for local/self-hosted development:
-
-```bash
-export POSTGRES_PASSWORD=...
-export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
-cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
-```
-
-That flow now does the first non-hand-wavy useful slice: it can paginate snapshot reads into multiple staged JSONL.gz chunks, persist a local checkpoint ledger under `.astra/checkpoints`, and resume from the next unfinished chunk on rerun. The implementation is still intentionally local-first and narrow: offset-based chunk pagination for Podman/dev workflows, no sink apply yet, and no fake cloud dependencies.
-
-Example:
-
-```bash
-export POSTGRES_PASSWORD=...
+export ASTRA_SMOKE_PG_PASSWORD=astra
 export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
 export ASTRA_CHECKPOINT_LOCAL_ROOT=.astra/checkpoints
-cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml --chunk-size 5000
+
+cargo run -p astra -- execute-local-snapshot \
+  examples/smoke-local-snapshot.astra.yaml \
+  --control-plane-url http://127.0.0.1:8080
 ```
 
-Useful flags:
-
-- `--chunk-size <rows>` overrides `source.capture.snapshot.chunkSize`
-- `--checkpoint-root <dir>` changes where the local resume ledger is stored
-- `--no-resume` ignores any existing ledger and starts from chunk sequence 0 again
-
-There is now a matching narrow-but-real destination leg for local/self-hosted Postgres raw loading:
+### 6. Verify
 
 ```bash
-export POSTGRES_PASSWORD=...
-export WAREHOUSE_PASSWORD=...
-export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
-cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-postgres-raw.astra.yaml --max-rows-per-table 1000
-cargo run -p astra -- load-local-staging-to-postgres examples/postgres-to-postgres-raw.astra.yaml
+psql postgres://astra:astra@localhost:5432/astra \
+  -c "SELECT COUNT(*) FROM astra_raw.raw_public_smoke_users;"
+# expect: 20
+
+psql postgres://astra:astra@localhost:5432/astra \
+  -c "SELECT COUNT(*) FROM astra_raw.raw_public_smoke_orders;"
+# expect: 50
 ```
 
-If you want one boring command that runs that same local happy path end to end, use:
+Check run history in the UI or via API:
 
 ```bash
-export POSTGRES_PASSWORD=...
-export WAREHOUSE_PASSWORD=...
-export ASTRA_STAGING_LOCAL_ROOT=.astra/staging
-export ASTRA_CHECKPOINT_LOCAL_ROOT=.astra/checkpoints
-cargo run -p astra -- execute-local-snapshot examples/postgres-to-postgres-raw.astra.yaml --max-rows-per-table 1000
+curl http://127.0.0.1:8080/api/v1/pipelines
+curl http://127.0.0.1:8080/api/v1/pipelines/smoke-local-snapshot/run-history
 ```
 
-`execute-local-snapshot` is intentionally narrow and honest: it orchestrates the existing `snapshot-to-local-staging` and `load-local-staging-to-postgres` commands, prints stage-level progress, and currently supports the local Postgres-source to Postgres-destination slice only.
+---
 
-The loader reads staged `JSONL.gz` chunks and lands them in raw Postgres tables (default schema `astra_raw`) with one `jsonb` payload column plus loader metadata. It also records applied chunk object keys so reruns skip already-loaded chunks instead of duplicating them like idiots.
+## CLI commands
 
-If you want the same flow against a local MinIO bucket instead of the filesystem, bring up the Podman Compose stack and run:
+| Command | What it does |
+|---------|-------------|
+| `validate` | Parse and validate a YAML spec |
+| `discover-source` | Enumerate Postgres tables, columns, and primary keys |
+| `snapshot-to-local-staging` | Snapshot Postgres tables to local JSONL.gz chunks |
+| `snapshot-to-minio-staging` | Snapshot Postgres tables to MinIO/S3 chunks |
+| `load-local-staging-to-postgres` | Load locally staged chunks into Postgres raw destination |
+| `execute-local-snapshot` | End-to-end: snapshot → local staging → Postgres load |
+
+## Control plane API
+
+All endpoints under `/api/v1/`. Key ones:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /pipelines` | List registered pipelines |
+| `POST /specs/apply` | Register or update a pipeline spec |
+| `GET /pipelines/:name/run-history` | Paginated run history |
+| `GET /pipeline-runs/:id/table-executions` | Per-table status and row counts |
+
+## Architecture
+
+Rust-first modular monolith. Single control-plane binary, Postgres for metadata, S3/MinIO for durable staging.
+
+```
+apps/control-plane   Axum HTTP API + scheduler + metadata
+apps/cli             Clap CLI
+apps/web             React 18 + TypeScript + Vite
+crates/astra-yaml    YAML spec parsing/validation (v1alpha1)
+crates/astra-runtime Staging — local, S3, MinIO; chunked JSONL.gz
+crates/astra-connectors  Postgres source + destination
+```
+
+See [`docs/v0.1-SCOPE.md`](docs/v0.1-SCOPE.md) for what is and isn't implemented, and [`docs/architecture/rfc-0001-v1-architecture.md`](docs/architecture/rfc-0001-v1-architecture.md) for the full architecture RFC.
+
+## Development
 
 ```bash
-export POSTGRES_PASSWORD=astra
-export ASTRA_S3_ENDPOINT=http://127.0.0.1:9000
-export ASTRA_S3_REGION=us-east-1
-export ASTRA_S3_ACCESS_KEY=astra
-export ASTRA_S3_SECRET_KEY=astrastorage
-cargo run -p astra -- snapshot-to-minio-staging examples/postgres-to-warehouse.astra.yaml --max-rows-per-table 1000
+cargo test --workspace          # run all tests
+cargo clippy --workspace        # lint
+cd apps/web && npm run dev      # Vite dev server at 127.0.0.1:4173
+python3 scripts/e2e_snapshot_smoke.py  # end-to-end smoke test
 ```
 
-That uses the same staging contract and object-key layout, just backed by a MinIO/S3-compatible adapter instead of local files. Same chunks, less pretending.
-
-The shell is intentionally lightweight and the React + TypeScript follow-up is tracked in issue #26.
-
-## Status
-
-Repo scaffold and planning docs have been initialized. The next real move is implementation, not more slideware.
+Copy `.env.example` to `.env` for a full reference of environment variables.

--- a/apps/cli/src/commands.rs
+++ b/apps/cli/src/commands.rs
@@ -208,7 +208,7 @@ pub async fn snapshot_to_local_staging(
         if let (Some(control_plane), Some(run_id)) = (&control_plane, run_id.as_deref()) {
             control_plane
                 .record_staged_artifact(
-                    &run_id,
+                    run_id,
                     &table.table,
                     "default",
                     table.sequence.try_into().context("sequence overflow")?,
@@ -221,7 +221,7 @@ pub async fn snapshot_to_local_staging(
                 .await?;
             control_plane
                 .upsert_table_execution(
-                    &run_id,
+                    run_id,
                     &table.table,
                     "staged",
                     chunk.row_count as i64,
@@ -259,7 +259,7 @@ pub async fn snapshot_to_local_staging(
         if let (Some(control_plane), Some(run_id)) = (&control_plane, run_id.as_deref()) {
             control_plane
                 .upsert_table_execution(
-                    &run_id,
+                    run_id,
                     &progress.table,
                     if progress.finished {
                         "snapshot_complete"
@@ -310,7 +310,7 @@ pub async fn snapshot_to_local_staging(
             .sum();
         control_plane
             .update_run_status(
-                &run_id,
+                run_id,
                 "succeeded",
                 Some(json!({
                     "tables_completed": tables_completed,
@@ -511,9 +511,9 @@ pub async fn load_local_staging_to_postgres(
         if let (Some(control_plane), Some(run_id)) = (&control_plane, run_id.as_deref()) {
             control_plane
                 .upsert_table_execution(
-                    &run_id,
+                    run_id,
                     &chunk.table_name,
-                    if chunk.skipped { "applied" } else { "applied" },
+                    "applied",
                     chunk.rows_written as i64,
                     Some(chunk.rows_written as i64),
                     None,
@@ -545,7 +545,7 @@ pub async fn load_local_staging_to_postgres(
             .sum();
         control_plane
             .update_run_status(
-                &run_id,
+                run_id,
                 "succeeded",
                 Some(json!({
                     "chunks_applied": report.applied_chunks.len(),
@@ -706,6 +706,7 @@ impl ControlPlaneClient {
             .context("control-plane create_pipeline_run response missing id")
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn record_staged_artifact(
         &self,
         run_id: &str,
@@ -741,6 +742,7 @@ impl ControlPlaneClient {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn upsert_table_execution(
         &self,
         run_id: &str,

--- a/apps/control-plane/src/api.rs
+++ b/apps/control-plane/src/api.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ApiModule;
 
 impl ApiModule {

--- a/apps/control-plane/src/metadata.rs
+++ b/apps/control-plane/src/metadata.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct MetadataModule;
 
 impl MetadataModule {

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -157,4 +157,3 @@ pub struct UpsertTableExecutionRequest {
     #[serde(default)]
     pub checkpoint_completed: Option<bool>,
 }
-

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -158,10 +158,3 @@ pub struct UpsertTableExecutionRequest {
     pub checkpoint_completed: Option<bool>,
 }
 
-pub enum RunStatus {
-    Pending,
-    Running,
-    Succeeded,
-    Failed,
-    Cancelled,
-}

--- a/apps/control-plane/src/scheduler.rs
+++ b/apps/control-plane/src/scheduler.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SchedulerModule;
 
 impl SchedulerModule {

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -155,6 +155,7 @@ impl PipelineService {
             .collect())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn record_staged_artifact(
         &self,
         pipeline_run_id: Uuid,

--- a/apps/worker/src/main.rs
+++ b/apps/worker/src/main.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
-use tracing::{error, info};
+use tracing::info;
 use uuid::Uuid;
 
 #[derive(Parser)]
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Running...");
 
     let start_time = Instant::now();
-    let stages = vec![
+    let stages = [
         ("Planning", Duration::from_secs(1)),
         ("Snapshot", Duration::from_secs(3)),
         ("StageFlush", Duration::from_secs(2)),


### PR DESCRIPTION
## Summary

- **CI** (`#110`): add `cargo clippy --workspace -- -D warnings` to `rust-foundation` and a new `rust-tests` job running `cargo test --workspace`. Previously only `cargo check` ran — the test suite never executed in CI.
- **README** (`#111`): full rewrite with prerequisites, 6-step end-to-end quickstart, CLI/API reference tables, and architecture summary. Old file was product copy with no actionable instructions.
- **CHANGELOG** (`#112`): created `CHANGELOG.md` with a complete `[0.1.0]` entry covering all shipped features and known limitations.

Closes #110, #111, #112.

## Test plan

- [ ] CI passes on this branch (rust-foundation, rust-tests, web-foundation, e2e-snapshot-smoke)
- [ ] Follow the README quickstart on a clean checkout and verify it works end-to-end
- [ ] Review CHANGELOG [0.1.0] entry against `docs/v0.1-SCOPE.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)