### PR TITLE
fix(runtime): switch AWS SDK to ring backend, eliminate aws-lc-sys

### DIFF
--- a/crates/astra-runtime/Cargo.toml
+++ b/crates/astra-runtime/Cargo.toml
@@ -14,6 +14,6 @@ serde_json.workspace = true
 anyhow.workspace = true
 tokio.workspace = true
 async-trait = "0.1"
-aws-config = "1"
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "behavior-version-latest"] }
 aws-credential-types = "1"
-aws-sdk-s3 = "1"
+aws-sdk-s3 = { version = "1", default-features = false, features = ["rt-tokio", "sigv4a", "http-1x", "rustls"] }


### PR DESCRIPTION
## Summary

- Disables `default-features` on `aws-config` and `aws-sdk-s3` (which pulled in `aws-lc-rs` → `aws-lc-sys@0.38.x`)
- Enables `aws-sdk-s3/rustls` feature instead, which uses the ring-based TLS stack (`legacy-rustls-ring` via hyper-0.14)
- `aws-lc-sys` is no longer present anywhere in the dependency tree

Closes Dependabot alerts #1 and #2 (both high severity):
- AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
- CRL Distribution Point Scope Check Logic Error in AWS-LC

`rustls-webpki@0.101.7` (medium, alert #3) remains — it comes from `rustls@0.21` in the legacy ring connector and requires a larger migration (Option B: replace AWS SDK with `object_store`).

## Test plan

- [ ] CI passes (rust-foundation, rust-tests, e2e-snapshot-smoke)
- [ ] `cargo tree --workspace -i aws-lc-sys` returns no matches
- [ ] MinIO staging still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)