### PR TITLE
refactor: use RecordStagedArtifactRecord in service API

### DIFF
--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -5,6 +5,7 @@ use crate::{
         RecordStagedArtifactRequest, StagedArtifactsResponse, TableExecutionResponse,
         TableExecutionsResponse, UpsertTableExecutionRequest,
     },
+    repositories::RecordStagedArtifactRecord,
     state::AppState,
 };
 use axum::{
@@ -126,20 +127,22 @@ pub async fn record_staged_artifact(
 
     let response = state
         .pipeline_service
-        .record_staged_artifact(
+        .record_staged_artifact(RecordStagedArtifactRecord {
             pipeline_run_id,
-            request.stream_name,
-            request.partition_key,
-            request.sequence,
-            request.bucket,
-            request.object_key,
-            request.bytes_written,
-            request.row_count,
-            request.content_type,
-            request.content_encoding,
-            request.schema_fingerprint,
-            request.metadata_json,
-        )
+            stream_name: request.stream_name,
+            partition_key: request.partition_key,
+            sequence: request.sequence,
+            bucket: request.bucket,
+            object_key: request.object_key,
+            bytes_written: request.bytes_written,
+            row_count: request.row_count,
+            content_type: request.content_type,
+            content_encoding: request.content_encoding,
+            schema_fingerprint: request.schema_fingerprint,
+            metadata_json: request
+                .metadata_json
+                .unwrap_or_else(|| serde_json::json!({})),
+        })
         .await?;
     Ok(Json(response))
 }

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -155,39 +155,14 @@ impl PipelineService {
             .collect())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn record_staged_artifact(
         &self,
-        pipeline_run_id: Uuid,
-        stream_name: String,
-        partition_key: String,
-        sequence: i64,
-        bucket: String,
-        object_key: String,
-        bytes_written: i64,
-        row_count: i64,
-        content_type: String,
-        content_encoding: String,
-        schema_fingerprint: Option<String>,
-        metadata_json: Option<serde_json::Value>,
+        mut record: RecordStagedArtifactRecord,
     ) -> anyhow::Result<StagedArtifactResponse> {
-        let artifact = self
-            .repository
-            .record_staged_artifact(RecordStagedArtifactRecord {
-                pipeline_run_id,
-                stream_name,
-                partition_key,
-                sequence,
-                bucket,
-                object_key,
-                bytes_written,
-                row_count,
-                content_type,
-                content_encoding,
-                schema_fingerprint,
-                metadata_json: metadata_json.unwrap_or_else(|| serde_json::json!({})),
-            })
-            .await?;
+        if record.metadata_json.is_null() {
+            record.metadata_json = serde_json::json!({});
+        }
+        let artifact = self.repository.record_staged_artifact(record).await?;
         Ok(StagedArtifactResponse {
             id: artifact.id,
             pipeline_run_id: artifact.pipeline_run_id,


### PR DESCRIPTION
## Summary
- change PipelineService::record_staged_artifact to accept RecordStagedArtifactRecord directly
- construct the record in the HTTP handler instead of threading 11 positional arguments through the service API
- keep metadata_json normalization in the service/handler flow so the repository still receives a complete record

Closes #124.

## Verification
- cargo test --manifest-path apps/control-plane/Cargo.toml
- control-plane unit/service tests pass
- pg-persistence integration tests still require container access and fail here with testcontainers client connect errors