### PR TITLE
refactor: type PipelineRecord status with PipelineStatus

### DIFF
--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     state::AppState,
 };
+use astra_metadata::PipelineStatus;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -219,7 +220,7 @@ pub async fn disable_pipeline(
 ) -> Result<Json<crate::models::api::PipelineSummaryResponse>, AppError> {
     let pipeline = state
         .pipeline_service
-        .update_pipeline_status(&pipeline_name, "disabled")
+        .update_pipeline_status(&pipeline_name, PipelineStatus::Disabled)
         .await?;
     Ok(Json(pipeline))
 }
@@ -230,7 +231,7 @@ pub async fn enable_pipeline(
 ) -> Result<Json<crate::models::api::PipelineSummaryResponse>, AppError> {
     let pipeline = state
         .pipeline_service
-        .update_pipeline_status(&pipeline_name, "active")
+        .update_pipeline_status(&pipeline_name, PipelineStatus::Active)
         .await?;
     Ok(Json(pipeline))
 }

--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -7,6 +7,7 @@ use crate::{
     },
 };
 use anyhow::anyhow;
+use astra_metadata::PipelineStatus;
 use async_trait::async_trait;
 use chrono::Utc;
 use sha2::{Digest, Sha256};
@@ -100,7 +101,7 @@ impl PipelineRepository for InMemoryPipelineRepository {
             name: name.clone(),
             source_kind: spec.source.kind.clone(),
             destination_kind: spec.destination.kind.clone(),
-            status: "active".to_string(),
+            status: PipelineStatus::Active,
             spec_version: next_version,
         };
 
@@ -370,12 +371,12 @@ impl PipelineRepository for InMemoryPipelineRepository {
     async fn update_pipeline_status(
         &self,
         pipeline_name: &str,
-        status: &str,
+        status: PipelineStatus,
     ) -> anyhow::Result<PipelineRecord> {
         let mut guard = self.inner.write().await;
         match guard.get_mut(pipeline_name) {
             Some(stored) => {
-                stored.record.status = status.to_string();
+                stored.record.status = status;
                 stored.updated_at = Utc::now();
                 Ok(stored.record.clone())
             }

--- a/apps/control-plane/src/repositories/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/pipeline_repository.rs
@@ -1,3 +1,4 @@
+use astra_metadata::PipelineStatus;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
@@ -8,7 +9,7 @@ pub struct PipelineRecord {
     pub name: String,
     pub source_kind: String,
     pub destination_kind: String,
-    pub status: String,
+    pub status: PipelineStatus,
     pub spec_version: i32,
 }
 
@@ -160,6 +161,6 @@ pub trait PipelineRepository: Send + Sync {
     async fn update_pipeline_status(
         &self,
         pipeline_name: &str,
-        status: &str,
+        status: PipelineStatus,
     ) -> anyhow::Result<PipelineRecord>;
 }

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -6,11 +6,12 @@ use crate::{
         UpsertTableExecutionRecord,
     },
 };
-use anyhow::Context;
+use anyhow::{anyhow, Context};
+use astra_metadata::PipelineStatus;
 use async_trait::async_trait;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
 use tokio_postgres::{types::Json, Client, NoTls, Row};
 use uuid::Uuid;
@@ -205,14 +206,8 @@ impl PipelineRepository for PostgresPipelineRepository {
 
         Ok(rows
             .into_iter()
-            .map(|row| PipelineRecord {
-                name: row.get("name"),
-                source_kind: row.get("source_kind"),
-                destination_kind: row.get("destination_kind"),
-                status: row.get("status"),
-                spec_version: row.get("spec_version"),
-            })
-            .collect())
+            .map(map_pipeline_row)
+            .collect::<anyhow::Result<Vec<_>>>()?)
     }
 
     async fn apply_spec(
@@ -224,7 +219,7 @@ impl PipelineRepository for PostgresPipelineRepository {
         let pipeline_name = spec.pipeline.name.clone();
         let source_kind = spec.source.kind.clone();
         let destination_kind = spec.destination.kind.clone();
-        let status = "active".to_string();
+        let status = PipelineStatus::Active;
         let spec_version_label = spec.version.clone();
         let spec_model: Value =
             serde_json::to_value(&spec).context("failed to serialize normalized spec JSON")?;
@@ -264,7 +259,7 @@ impl PipelineRepository for PostgresPipelineRepository {
                         name: pipeline_name,
                         source_kind,
                         destination_kind,
-                        status,
+                        status: status.clone(),
                         spec_version: active_version,
                     },
                     content_hash,
@@ -285,7 +280,7 @@ impl PipelineRepository for PostgresPipelineRepository {
                         &pipeline_name,
                         &source_kind,
                         &destination_kind,
-                        &status,
+                        &status.to_string(),
                     ],
                 )
                 .await
@@ -329,7 +324,7 @@ impl PipelineRepository for PostgresPipelineRepository {
                     &pipeline_id,
                     &source_kind,
                     &destination_kind,
-                    &status,
+                    &status.to_string(),
                     &spec_id,
                 ],
             )
@@ -631,7 +626,7 @@ impl PipelineRepository for PostgresPipelineRepository {
     async fn update_pipeline_status(
         &self,
         pipeline_name: &str,
-        status: &str,
+        status: PipelineStatus,
     ) -> anyhow::Result<PipelineRecord> {
         let row = self
             .client
@@ -645,22 +640,26 @@ impl PipelineRepository for PostgresPipelineRepository {
                 RETURNING name, source_kind, destination_kind, status,
                           (SELECT version FROM pipeline_specs WHERE id = active_spec_id) AS spec_version
                 "#,
-                &[&status, &pipeline_name],
+                &[&status.to_string(), &pipeline_name],
             )
             .await
             .with_context(|| format!("failed to update status for pipeline '{}'", pipeline_name))?;
 
         match row {
-            Some(r) => Ok(PipelineRecord {
-                name: r.get("name"),
-                source_kind: r.get("source_kind"),
-                destination_kind: r.get("destination_kind"),
-                status: r.get("status"),
-                spec_version: r.get::<_, Option<i32>>("spec_version").unwrap_or(0),
-            }),
+            Some(r) => Ok(map_pipeline_row(r)?),
             None => Err(anyhow::Error::new(NotFoundError(pipeline_name.to_string()))),
         }
     }
+}
+
+fn map_pipeline_row(row: Row) -> anyhow::Result<PipelineRecord> {
+    Ok(PipelineRecord {
+        name: row.get("name"),
+        source_kind: row.get("source_kind"),
+        destination_kind: row.get("destination_kind"),
+        status: parse_pipeline_status(row.get("status"))?,
+        spec_version: row.get::<_, Option<i32>>("spec_version").unwrap_or(0),
+    })
 }
 
 fn map_table_execution_row(row: Row) -> TableExecutionRecord {
@@ -726,4 +725,8 @@ fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+fn parse_pipeline_status(status: String) -> anyhow::Result<PipelineStatus> {
+    PipelineStatus::from_str(&status).map_err(|err| anyhow!(err))
 }

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -8,6 +8,7 @@ use crate::{
         UpsertTableExecutionRecord,
     },
 };
+use astra_metadata::PipelineStatus;
 use chrono::Utc;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -29,7 +30,7 @@ impl PipelineService {
                 name: p.name,
                 source_kind: p.source_kind,
                 destination_kind: p.destination_kind,
-                status: p.status,
+                status: p.status.to_string(),
                 spec_version: p.spec_version,
             })
             .collect())
@@ -309,18 +310,8 @@ impl PipelineService {
     pub async fn update_pipeline_status(
         &self,
         pipeline_name: &str,
-        status: &str,
+        status: PipelineStatus,
     ) -> anyhow::Result<PipelineSummaryResponse> {
-        const VALID_STATUSES: &[&str] = &[
-            "draft", "active", "disabled", "paused", "failed", "archived",
-        ];
-        if !VALID_STATUSES.contains(&status) {
-            anyhow::bail!(
-                "invalid pipeline status '{}'; must be one of: {}",
-                status,
-                VALID_STATUSES.join(", ")
-            );
-        }
         let record = self
             .repository
             .update_pipeline_status(pipeline_name, status)
@@ -329,7 +320,7 @@ impl PipelineService {
             name: record.name,
             source_kind: record.source_kind,
             destination_kind: record.destination_kind,
-            status: record.status,
+            status: record.status.to_string(),
             spec_version: record.spec_version,
         })
     }

--- a/apps/control-plane/tests/checkpoint_metadata.rs
+++ b/apps/control-plane/tests/checkpoint_metadata.rs
@@ -6,6 +6,7 @@ use astra_control_plane::{
     services::PipelineService,
     InMemoryPipelineRepository,
 };
+use astra_metadata::PipelineStatus;
 
 #[tokio::test]
 async fn table_execution_checkpoint_metadata_round_trips_via_service() -> Result<()> {
@@ -179,19 +180,19 @@ runtime:
 
     // Disable it
     let disabled = service
-        .update_pipeline_status("test-lifecycle-pipeline", "disabled")
+        .update_pipeline_status("test-lifecycle-pipeline", PipelineStatus::Disabled)
         .await?;
     assert_eq!(disabled.status, "disabled");
 
     // Re-enable it
     let enabled = service
-        .update_pipeline_status("test-lifecycle-pipeline", "active")
+        .update_pipeline_status("test-lifecycle-pipeline", PipelineStatus::Active)
         .await?;
     assert_eq!(enabled.status, "active");
 
     // Disabling a non-existent pipeline returns an error
     let err = service
-        .update_pipeline_status("no-such-pipeline", "disabled")
+        .update_pipeline_status("no-such-pipeline", PipelineStatus::Disabled)
         .await;
     assert!(err.is_err());
 

--- a/apps/control-plane/tests/pg-persistence.rs
+++ b/apps/control-plane/tests/pg-persistence.rs
@@ -4,6 +4,7 @@ use astra_control_plane::repositories::{
     PipelineRepository, PipelineRunRecord, PostgresPipelineRepository, RecordStagedArtifactRecord,
     StagedArtifactRecord,
 };
+use astra_metadata::PipelineStatus;
 use astra_yaml::AstraSpec;
 use chrono::Utc;
 use serde_json::json;
@@ -75,7 +76,7 @@ runtime:
         .apply_spec(spec.clone(), raw_yaml.clone(), None)
         .await?;
     assert_eq!(applied.pipeline.name, pipeline_name);
-    assert_eq!(applied.pipeline.status, "active");
+    assert_eq!(applied.pipeline.status, PipelineStatus::Active);
 
     // create_run
     let now = Utc::now();
@@ -224,14 +225,14 @@ runtime:
 
     // Test disable / enable (update_pipeline_status)
     let disabled = repo3
-        .update_pipeline_status(&pipeline_name, "disabled")
+        .update_pipeline_status(&pipeline_name, PipelineStatus::Disabled)
         .await?;
-    assert_eq!(disabled.status, "disabled");
+    assert_eq!(disabled.status, PipelineStatus::Disabled);
 
     let enabled = repo3
-        .update_pipeline_status(&pipeline_name, "active")
+        .update_pipeline_status(&pipeline_name, PipelineStatus::Active)
         .await?;
-    assert_eq!(enabled.status, "active");
+    assert_eq!(enabled.status, PipelineStatus::Active);
 
     // Test delete_pipeline removes the pipeline and cascades
     repo3.delete_pipeline(&pipeline_name).await?;

--- a/crates/astra-metadata/src/lib.rs
+++ b/crates/astra-metadata/src/lib.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::{fmt, str::FromStr};
 use uuid::Uuid;
 
 pub const CRATE_NAME: &str = "astra-metadata";
@@ -14,6 +15,36 @@ pub enum PipelineStatus {
     Paused,
     Failed,
     Archived,
+}
+
+impl fmt::Display for PipelineStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Draft => "draft",
+            Self::Active => "active",
+            Self::Disabled => "disabled",
+            Self::Paused => "paused",
+            Self::Failed => "failed",
+            Self::Archived => "archived",
+        };
+        f.write_str(value)
+    }
+}
+
+impl FromStr for PipelineStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draft" => Ok(Self::Draft),
+            "active" => Ok(Self::Active),
+            "disabled" => Ok(Self::Disabled),
+            "paused" => Ok(Self::Paused),
+            "failed" => Ok(Self::Failed),
+            "archived" => Ok(Self::Archived),
+            _ => Err(format!("invalid pipeline status '{s}'")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- change PipelineRecord to use astra_metadata::PipelineStatus instead of String
- add Display and FromStr support for PipelineStatus and make Postgres mapping explicit and type-checked
- remove the manual valid-status list from PipelineService and update handlers/tests to pass typed statuses

Closes #125.

## Verification
- cargo test --manifest-path apps/control-plane/Cargo.toml
- control-plane unit/service tests pass
- pg-persistence integration tests still require container access and fail here with testcontainers client connect errors