### PR TITLE
feat: embedded pipeline executor — trigger runs from UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "astra-api",
+ "astra-connectors",
  "astra-core",
  "astra-metadata",
  "astra-observability",
+ "astra-runtime",
  "astra-secrets",
  "astra-yaml",
  "async-trait",

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -28,6 +28,8 @@ astra-core = { path = "../../crates/astra-core" }
 astra-metadata = { path = "../../crates/astra-metadata" }
 astra-observability = { path = "../../crates/astra-observability" }
 astra-secrets = { path = "../../crates/astra-secrets" }
+astra-connectors = { path = "../../crates/astra-connectors" }
+astra-runtime = { path = "../../crates/astra-runtime" }
 astra-yaml = { path = "../../crates/astra-yaml" }
 
 [dev-dependencies]

--- a/apps/control-plane/src/executor.rs
+++ b/apps/control-plane/src/executor.rs
@@ -1,0 +1,255 @@
+use crate::{
+    models::api::UpsertTableExecutionRequest, repositories::RecordStagedArtifactRecord,
+    services::PipelineService,
+};
+use astra_connectors::{PostgresDestinationLoader, PostgresSource, SnapshotExecutionOptions};
+use astra_runtime::{
+    LocalCheckpointStore, LocalStageChunkStore, LocalStagingConfig, StageChunkPayload,
+    StageChunkRequest, StageChunkStore, StagingConfig, StagingKind,
+};
+use astra_yaml::AstraSpec;
+use serde_json::json;
+use std::{collections::BTreeMap, sync::Arc};
+use uuid::Uuid;
+
+/// Runs a full snapshot → load pipeline in a background Tokio task.
+/// On completion or failure, updates the run record via `PipelineService`.
+/// Intended to be called with `tokio::spawn`.
+pub async fn execute_pipeline(service: Arc<PipelineService>, run_id: Uuid, yaml: String) {
+    tracing::info!(%run_id, "embedded executor: pipeline run started");
+    match run_pipeline(Arc::clone(&service), run_id, &yaml).await {
+        Ok(()) => {
+            tracing::info!(%run_id, "embedded executor: pipeline run succeeded");
+        }
+        Err(e) => {
+            tracing::error!(%run_id, error = ?e, "embedded executor: pipeline run failed");
+            let _ = service
+                .update_pipeline_run_status(
+                    run_id,
+                    "failed".to_string(),
+                    None,
+                    None,
+                    Some(json!({ "error": e.to_string() })),
+                )
+                .await;
+        }
+    }
+}
+
+async fn run_pipeline(
+    service: Arc<PipelineService>,
+    run_id: Uuid,
+    yaml: &str,
+) -> anyhow::Result<()> {
+    let spec = AstraSpec::parse_yaml(yaml)?;
+    spec.validate()?;
+
+    if spec.requests_cdc() {
+        anyhow::bail!("CDC execution is not yet supported by the embedded executor");
+    }
+    if spec.source.kind != "postgres" {
+        anyhow::bail!("embedded executor currently supports source.kind=postgres only");
+    }
+    if spec.destination.kind != "postgres" {
+        anyhow::bail!("embedded executor currently supports destination.kind=postgres only");
+    }
+
+    // Ephemeral staging area, unique per run — cleaned up on completion
+    let staging_root = std::env::temp_dir().join(format!("astra/{}", run_id));
+    let checkpoint_root = staging_root.join("checkpoints");
+
+    let staging_config = StagingConfig {
+        kind: StagingKind::Local,
+        bucket: "astra-staging".to_string(),
+        prefix: String::new(),
+    };
+    let store = LocalStageChunkStore::new(LocalStagingConfig {
+        root_dir: staging_root.clone(),
+        storage: staging_config,
+    });
+    store.ensure_ready().await?;
+
+    let checkpoint_store = LocalCheckpointStore::new(checkpoint_root);
+    checkpoint_store.ensure_ready()?;
+
+    // ── Phase 1: Snapshot ────────────────────────────────────────────────────
+
+    service
+        .update_pipeline_run_status(
+            run_id,
+            "running".to_string(),
+            Some("snapshot".to_string()),
+            None,
+            None,
+        )
+        .await?;
+
+    let source = PostgresSource::from_spec(&spec)?;
+    let snapshot = source
+        .snapshot_to_jsonl_gzip(SnapshotExecutionOptions {
+            tables: spec
+                .source
+                .capture
+                .tables
+                .iter()
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect(),
+            max_rows_per_table: None,
+            chunk_size: None,
+            start_sequence_by_table: BTreeMap::new(),
+        })
+        .await?;
+
+    for table in snapshot.tables {
+        let chunk = store
+            .write_chunk(StageChunkRequest {
+                pipeline_name: spec.pipeline.name.clone(),
+                stream_name: table.table.clone(),
+                partition_key: "default".to_string(),
+                sequence: table.sequence,
+                payload: StageChunkPayload::jsonl_gzip(table.row_count, table.rows_jsonl_gzip),
+            })
+            .await?;
+
+        checkpoint_store.record_chunk_staged(
+            &spec.pipeline.name,
+            &table.table,
+            table.sequence,
+            chunk.row_count,
+            &chunk.object_key,
+        )?;
+
+        service
+            .record_staged_artifact(RecordStagedArtifactRecord {
+                pipeline_run_id: run_id,
+                stream_name: table.table.clone(),
+                partition_key: "default".to_string(),
+                sequence: table.sequence.try_into()?,
+                bucket: chunk.bucket.clone(),
+                object_key: chunk.object_key.clone(),
+                bytes_written: chunk.bytes_written as i64,
+                row_count: chunk.row_count as i64,
+                content_type: "application/jsonl".to_string(),
+                content_encoding: "gzip".to_string(),
+                schema_fingerprint: None,
+                metadata_json: json!({ "sql": table.sql }),
+            })
+            .await?;
+
+        service
+            .upsert_table_execution(
+                run_id,
+                UpsertTableExecutionRequest {
+                    stream_name: table.table.clone(),
+                    status: "staged".to_string(),
+                    rows_processed: chunk.row_count as i64,
+                    rows_total: Some(chunk.row_count as i64),
+                    error_summary: None,
+                    checkpoint_next_sequence: Some((table.sequence + 1).try_into()?),
+                    checkpoint_rows_staged: Some(chunk.row_count as i64),
+                    checkpoint_last_chunk_key: Some(chunk.object_key.clone()),
+                    checkpoint_completed: Some(false),
+                },
+            )
+            .await?;
+    }
+
+    for progress in snapshot.table_progress {
+        if progress.finished {
+            checkpoint_store.mark_table_complete(&spec.pipeline.name, &progress.table)?;
+        }
+        service
+            .upsert_table_execution(
+                run_id,
+                UpsertTableExecutionRequest {
+                    stream_name: progress.table.clone(),
+                    status: if progress.finished {
+                        "snapshot_complete"
+                    } else {
+                        "snapshot_running"
+                    }
+                    .to_string(),
+                    rows_processed: progress.rows_emitted as i64,
+                    rows_total: None,
+                    error_summary: None,
+                    checkpoint_next_sequence: Some(progress.next_sequence.try_into()?),
+                    checkpoint_rows_staged: Some(progress.rows_emitted as i64),
+                    checkpoint_last_chunk_key: None,
+                    checkpoint_completed: Some(progress.finished),
+                },
+            )
+            .await?;
+    }
+
+    // ── Phase 2: Load to destination ─────────────────────────────────────────
+
+    service
+        .update_pipeline_run_status(
+            run_id,
+            "running".to_string(),
+            Some("load".to_string()),
+            None,
+            None,
+        )
+        .await?;
+
+    let loader = PostgresDestinationLoader::from_spec(&spec)?;
+    let staged_chunks = store.list_chunks_for_pipeline(&spec.pipeline.name)?;
+
+    if staged_chunks.is_empty() {
+        anyhow::bail!("snapshot produced no chunks — nothing to load");
+    }
+
+    let mut chunk_payloads = Vec::new();
+    for mut chunk in staged_chunks {
+        let bytes = store.read_chunk(&chunk).await?;
+        chunk.bytes_written = bytes.len() as u64;
+        chunk_payloads.push((chunk, bytes));
+    }
+
+    let report = loader.load_local_stage_chunks(chunk_payloads).await?;
+    let total_rows: i64 = report
+        .applied_chunks
+        .iter()
+        .map(|c| c.rows_written as i64)
+        .sum();
+
+    for chunk in &report.applied_chunks {
+        service
+            .upsert_table_execution(
+                run_id,
+                UpsertTableExecutionRequest {
+                    stream_name: chunk.table_name.clone(),
+                    status: "applied".to_string(),
+                    rows_processed: chunk.rows_written as i64,
+                    rows_total: Some(chunk.rows_written as i64),
+                    error_summary: None,
+                    checkpoint_next_sequence: None,
+                    checkpoint_rows_staged: Some(chunk.rows_written as i64),
+                    checkpoint_last_chunk_key: Some(chunk.object_key.clone()),
+                    checkpoint_completed: Some(true),
+                },
+            )
+            .await?;
+    }
+
+    service
+        .update_pipeline_run_status(
+            run_id,
+            "succeeded".to_string(),
+            None,
+            None,
+            Some(json!({
+                "chunks_applied": report.applied_chunks.len(),
+                "rows_written": total_rows,
+                "schema": report.schema,
+            })),
+        )
+        .await?;
+
+    // Clean up ephemeral staging
+    let _ = std::fs::remove_dir_all(&staging_root);
+
+    Ok(())
+}

--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -27,6 +27,10 @@ pub fn routes() -> Router<AppState> {
             post(pipelines::enable_pipeline),
         )
         .route(
+            "/api/v1/pipelines/:pipeline_name/trigger",
+            post(pipelines::trigger_pipeline),
+        )
+        .route(
             "/api/v1/pipelines/:pipeline_name/runs",
             get(pipelines::list_pipeline_runs),
         )

--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -3,7 +3,7 @@ use crate::{
     models::api::{
         ApplySpecRequest, CreatePipelineRunRequest, PipelineRunsResponse, PipelinesResponse,
         RecordStagedArtifactRequest, StagedArtifactsResponse, TableExecutionResponse,
-        TableExecutionsResponse, UpsertTableExecutionRequest,
+        TableExecutionsResponse, TriggerPipelineResponse, UpsertTableExecutionRequest,
     },
     repositories::RecordStagedArtifactRecord,
     state::AppState,
@@ -14,6 +14,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use std::sync::Arc;
 use uuid::Uuid;
 
 pub async fn list_pipelines(
@@ -237,4 +238,34 @@ pub async fn enable_pipeline(
         .update_pipeline_status(&pipeline_name, PipelineStatus::Active)
         .await?;
     Ok(Json(pipeline))
+}
+
+pub async fn trigger_pipeline(
+    State(state): State<AppState>,
+    Path(pipeline_name): Path<String>,
+) -> Result<Json<TriggerPipelineResponse>, AppError> {
+    let yaml = state
+        .pipeline_service
+        .get_pipeline_yaml(&pipeline_name)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("pipeline '{pipeline_name}' not found")))?;
+
+    let run = state
+        .pipeline_service
+        .create_pipeline_run(
+            pipeline_name,
+            "ui-trigger".to_string(),
+            Some("running".to_string()),
+            None,
+            None,
+        )
+        .await?;
+
+    let run_id = run.id;
+    let service = Arc::clone(&state.pipeline_service);
+    tokio::spawn(async move {
+        crate::executor::execute_pipeline(service, run_id, yaml).await;
+    });
+
+    Ok(Json(TriggerPipelineResponse { run_id }))
 }

--- a/apps/control-plane/src/lib.rs
+++ b/apps/control-plane/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod app;
 pub mod config;
 pub mod error;
+pub mod executor;
 pub mod http;
 pub mod metadata;
 pub mod models;

--- a/apps/control-plane/src/main.rs
+++ b/apps/control-plane/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod app;
 mod config;
 mod error;
+mod executor;
 mod http;
 mod metadata;
 mod models;

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -214,6 +214,11 @@ pub struct TableExecutionsResponse {
     pub tables: Vec<TableExecutionResponse>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct TriggerPipelineResponse {
+    pub run_id: Uuid,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct UpsertTableExecutionRequest {
     pub stream_name: String,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -74,3 +74,14 @@ export async function enablePipeline(pipelineName: string): Promise<PipelineSumm
   }
   return res.json() as Promise<PipelineSummaryResponse>;
 }
+
+export async function triggerPipeline(pipelineName: string): Promise<{ run_id: string }> {
+  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/trigger`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(errorText || `Trigger failed with status ${res.status}`);
+  }
+  return res.json() as Promise<{ run_id: string }>;
+}

--- a/apps/web/src/components/PipelineList.tsx
+++ b/apps/web/src/components/PipelineList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { Pipeline, RunHistoryState, TableExecutionState } from '@/types';
-import { fetchPipelines, fetchRunHistory, fetchTableExecutions, deletePipeline, disablePipeline, enablePipeline } from '@/api';
+import { fetchPipelines, fetchRunHistory, fetchTableExecutions, deletePipeline, disablePipeline, enablePipeline, triggerPipeline } from '@/api';
 import { formatDuration, formatTimestamp, formatRowProgress, runStatusVariant, tableStatusVariant } from '@/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -141,6 +141,44 @@ export function PipelineList({ refreshToken }: Props) {
       });
   }
 
+  function handleRunPipeline(pipelineName: string) {
+    const key = `run-${pipelineName}`;
+    setActionLoading((a) => ({ ...a, [key]: true }));
+    triggerPipeline(pipelineName)
+      .then(() => {
+        // Expand runs panel so the user sees the new run appear
+        setExpandedPipelines((prev) => {
+          const next = new Set(prev);
+          next.add(pipelineName);
+          return next;
+        });
+        setRunHistories((h) => ({
+          ...h,
+          [pipelineName]: { loading: true, error: null, runs: h[pipelineName]?.runs ?? [] },
+        }));
+        fetchRunHistory(pipelineName)
+          .then((data) =>
+            setRunHistories((h) => ({ ...h, [pipelineName]: { loading: false, error: null, runs: data.runs } }))
+          )
+          .catch((err: unknown) =>
+            setRunHistories((h) => ({
+              ...h,
+              [pipelineName]: {
+                loading: false,
+                error: err instanceof Error ? err.message : 'Failed to load run history.',
+                runs: [],
+              },
+            }))
+          );
+      })
+      .catch((err: unknown) => {
+        alert(err instanceof Error ? err.message : `Failed to trigger pipeline "${pipelineName}".`);
+      })
+      .finally(() => {
+        setActionLoading((a) => ({ ...a, [key]: false }));
+      });
+  }
+
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between space-y-0">
@@ -166,6 +204,7 @@ export function PipelineList({ refreshToken }: Props) {
               const isDisabled = pipeline.status === 'disabled';
               const statusLoading = actionLoading[`status-${pipeline.name}`] ?? false;
               const deleteLoading = actionLoading[`delete-${pipeline.name}`] ?? false;
+              const runLoading = actionLoading[`run-${pipeline.name}`] ?? false;
 
               return (
                 <div key={`${pipeline.name}-${pipeline.spec_version}`}>
@@ -187,6 +226,14 @@ export function PipelineList({ refreshToken }: Props) {
                         onClick={() => handleToggleRuns(pipeline.name)}
                       >
                         {isExpanded ? 'Hide runs' : 'View runs'}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={runLoading || isDisabled}
+                        onClick={() => handleRunPipeline(pipeline.name)}
+                      >
+                        {runLoading ? 'Running…' : 'Run'}
                       </Button>
                       <Button
                         variant="outline"


### PR DESCRIPTION
## Summary

- Eliminates the requirement to have a local YAML file and run the CLI manually to execute a pipeline
- The control plane now reads the spec from its own database and runs the full snapshot → load flow in an embedded background Tokio task
- A **Run** button is added to the pipeline list UI

## Changes

**Backend**
- New `executor` module (`src/executor.rs`) — two-phase execution: Postgres snapshot → ephemeral local staging → Postgres raw load
- `POST /api/v1/pipelines/:name/trigger` — returns `{ run_id }` immediately; actual execution is async in the background
- Ephemeral per-run temp dir for staging, cleaned up after completion
- Run status, staged artifacts, and per-table execution records are reported in real time via `PipelineService`

**Frontend**
- **Run** button per pipeline row in `PipelineList.tsx`; disabled while in-flight or when the pipeline is disabled
- On trigger, the run history panel auto-expands and refreshes so the new run is immediately visible
- `triggerPipeline()` added to `api.ts`

## Test plan

- [ ] Start the control plane with source/destination env vars set (e.g. `POSTGRES_PASSWORD=...`)
- [ ] Apply a pipeline spec via the UI
- [ ] Click **Run** — run history panel should open and show a new `running` run
- [ ] Wait for completion — status should flip to `succeeded` with table executions visible
- [ ] Verify rows landed in the destination's `astra_raw` schema
- [ ] Confirm CLI workflow (`snapshot-to-local-staging`, `execute-local-snapshot`) still works unchanged

## Known limitations (pre-existing, not introduced here)

- Re-running a pipeline appends all rows again — the raw layer has no upsert/deduplication across runs (tracked separately)
- Embedded executor supports `source.kind=postgres` + `destination.kind=postgres` only; CDC returns an explicit error

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)