### PR TITLE
fix: restore baseUrl to /Astra/ (repo not yet renamed)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,10 +9,10 @@ const config = {
   favicon: 'img/favicon.ico',
 
   url: 'https://astra-core.github.io',
-  baseUrl: '/',
+  baseUrl: '/Astra/',
 
   organizationName: 'astra-core',
-  projectName: 'astra-core.github.io',
+  projectName: 'Astra',
   deploymentBranch: 'gh-pages',
   trailingSlash: false,
 


### PR DESCRIPTION
The repo is still named `Astra` so GitHub Pages serves the site at `astra-core.github.io/Astra/`. The previous PR set `baseUrl: '/'` which caused all assets to 404 and the Docusaurus load error.

This restores `baseUrl: '/Astra/'` and `projectName: 'Astra'` so the site loads correctly at its current URL.

**When you rename the repo to `astra-core.github.io`**, revert this — set `baseUrl: '/'` and `projectName: 'astra-core.github.io'` at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)