### PR TITLE
docs: sync documentation with v0.1 implementation

### DIFF
--- a/website/docs/architecture/staging-contract.md
+++ b/website/docs/architecture/staging-contract.md
@@ -19,19 +19,20 @@ Every staged chunk carries this metadata:
 | `partition` | `String` | Partition identifier (currently `"default"`) |
 | `sequence` | `u64` | Monotonically increasing chunk number within the stream |
 | `row_count` | `u64` | Number of rows in this chunk |
-| `schema_fingerprint` | `String` | Hash of the source schema at capture time |
 | `object_key` | `String` | Full object key for the chunk file |
 
 ## Object key convention
 
 ```
-pipelines/<pipeline>/streams/<stream>/partitions/<partition>/chunks/<sequence>.jsonl.gz
+pipelines/<pipeline>/streams/<stream>/partitions/<partition>/chunks/<sequence:020>.jsonl.gz
 ```
 
-Example:
+The sequence number is zero-padded to 20 digits to ensure lexicographic ordering.
+
+**Example:**
 
 ```
-pipelines/smoke-local-snapshot/streams/public.smoke_users/partitions/default/chunks/00000001.jsonl.gz
+pipelines/smoke-local-snapshot/streams/public.smoke_users/partitions/default/chunks/00000000000000000001.jsonl.gz
 ```
 
 ### Local adapter
@@ -42,7 +43,7 @@ For local staging, the key is prefixed with the local root and bucket:
 $ASTRA_STAGING_LOCAL_ROOT/<bucket>/<key>
 ```
 
-Example:
+**Example:**
 
 ```
 .astra/staging/astra-smoke-staging/pipelines/smoke-local-snapshot/...
@@ -50,7 +51,7 @@ Example:
 
 ### MinIO / S3 adapter
 
-The key is used as-is within the configured S3 bucket. The `ASTRA_S3_ENDPOINT`, `ASTRA_S3_REGION`, `ASTRA_S3_ACCESS_KEY`, and `ASTRA_S3_SECRET_KEY` variables control the connection.
+The key is used as-is within the configured S3 bucket. The `ASTRA_S3_ENDPOINT`, `ASTRA_S3_REGION`, `ASTRA_S3_ACCESS_KEY`, and `ASTRA_S3_SECRET_KEY` variables control the connection. Both MinIO and AWS S3 use the same `MinioStageChunkStore` implementation backed by the `object_store` crate.
 
 ## Chunk format
 
@@ -70,23 +71,34 @@ Each chunk file is a gzip-compressed JSONL file:
 
 ## Checkpoint ledger
 
-The checkpoint ledger tracks which chunks have been captured and (separately) which have been applied to the destination.
+The checkpoint ledger tracks which chunks have been staged so that interrupted runs can resume without re-capturing.
 
 **Ledger file location:**
 
 ```
-$ASTRA_CHECKPOINT_LOCAL_ROOT/<pipeline-name>/<stream-name>.ledger
+$ASTRA_CHECKPOINT_LOCAL_ROOT/<pipeline-name>.snapshot-checkpoints.json
 ```
 
-**Ledger entry format:**
+There is one JSON file per pipeline (not per stream). It contains a `SnapshotCheckpointLedger` with per-table `SnapshotTableCheckpoint` entries tracking the cursor value and list of staged chunks.
+
+**Example entry:**
 
 ```json
 {
-  "object_key": "pipelines/smoke-local-snapshot/streams/public.smoke_users/...",
-  "sequence": 1,
-  "row_count": 1000,
-  "cursor_value": "2024-01-15T10:05:42Z",
-  "staged_at": "2024-01-15T10:05:43Z"
+  "pipeline_name": "smoke-local-snapshot",
+  "tables": {
+    "public.smoke_users": {
+      "cursor_value": null,
+      "staged_chunks": [
+        {
+          "object_key": "pipelines/smoke-local-snapshot/streams/public.smoke_users/...",
+          "sequence": 1,
+          "row_count": 1000
+        }
+      ],
+      "complete": true
+    }
+  }
 }
 ```
 
@@ -96,19 +108,23 @@ The Postgres destination records applied chunks in `astra_raw._applied_chunks`:
 
 ```sql
 CREATE TABLE astra_raw._applied_chunks (
-    object_key   TEXT PRIMARY KEY,
-    applied_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    pipeline_name  TEXT        NOT NULL,
+    stream_name    TEXT        NOT NULL,
+    sequence       BIGINT      NOT NULL,
+    row_count      BIGINT,
+    loaded_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (pipeline_name, stream_name, sequence)
 );
 ```
 
-This makes the load phase idempotent: re-running `execute-local-snapshot` skips already-applied chunks.
+Each chunk load uses `INSERT ... ON CONFLICT DO NOTHING` on this table within a transaction, making the load phase idempotent: re-running `execute-local-snapshot` or `load-local-staging-to-postgres` skips already-applied chunks.
 
 ## Backend implementations
 
-| Backend | Kind value | Implementation crate |
+| Backend | Kind value | Implementation |
 |---|---|---|
-| Local filesystem | `local` | `crates/astra-runtime` |
-| MinIO | `minio` | `crates/astra-runtime` |
-| AWS S3 | `s3` | `crates/astra-runtime` |
+| Local filesystem | `local` | `LocalStageChunkStore` in `crates/astra-runtime` |
+| MinIO | `minio` | `MinioStageChunkStore` in `crates/astra-runtime` |
+| AWS S3 | `s3` | `MinioStageChunkStore` in `crates/astra-runtime` (same impl, custom endpoint) |
 
-All three implement the same `StagingBackend` trait. The pipeline spec's `destination.staging.kind` selects which implementation is used at runtime.
+All three implement the `StageChunkStore` async trait. The pipeline spec's `destination.staging.kind` selects which implementation is used at runtime.

--- a/website/docs/cli/reference.md
+++ b/website/docs/cli/reference.md
@@ -30,10 +30,26 @@ cargo run -p astra -- validate <spec-file>
 
 ```bash
 cargo run -p astra -- validate examples/smoke-local-snapshot.astra.yaml
-# Pipeline spec is valid.
+# valid Astra spec: smoke-local-snapshot  mode=snapshot  source=postgres  dest=postgres  tables=["public.smoke_users","public.smoke_orders"]
 ```
 
 Exits with code 0 on success, non-zero on validation errors. All validation errors are printed to stderr.
+
+---
+
+### `apply`
+
+Validate a pipeline spec and print the normalized representation. Intended to send the spec to the control-plane API — full API submission is not yet wired up in v0.1.
+
+```bash
+cargo run -p astra -- apply <spec-file>
+```
+
+**Example:**
+
+```bash
+cargo run -p astra -- apply my-pipeline.astra.yaml
+```
 
 ---
 
@@ -58,10 +74,10 @@ Output includes table names, column names, data types, nullability, and primary 
 
 ### `snapshot-to-local-staging`
 
-Run the capture phase: paginate through source tables and write compressed JSONL.gz chunks to the configured staging location.
+Run the capture phase: paginate through source tables and write compressed JSONL.gz chunks to a local directory.
 
 ```bash
-cargo run -p astra -- snapshot-to-local-staging <spec-file> [--no-resume]
+cargo run -p astra -- snapshot-to-local-staging <spec-file> [options]
 ```
 
 **Options:**
@@ -69,12 +85,17 @@ cargo run -p astra -- snapshot-to-local-staging <spec-file> [--no-resume]
 | Flag | Description |
 |---|---|
 | `--no-resume` | Ignore existing checkpoints and restart from scratch. |
+| `--max-rows-per-table <N>` | Stop after capturing N rows per table (useful for testing). |
+| `--staging-root <PATH>` | Override the local staging root directory. |
+| `--checkpoint-root <PATH>` | Override the checkpoint ledger root directory. |
+| `--chunk-size <N>` | Override the chunk size from the spec. |
+| `--control-plane-url <URL>` | Control plane URL for recording run metadata. |
 
 **Example:**
 
 ```bash
-POSTGRES_PASSWORD=secret \
-  cargo run -p astra -- snapshot-to-local-staging my-pipeline.astra.yaml
+ASTRA_SMOKE_PG_PASSWORD=astra \
+  cargo run -p astra -- snapshot-to-local-staging examples/smoke-local-snapshot.astra.yaml
 ```
 
 **What it does:**
@@ -84,78 +105,108 @@ POSTGRES_PASSWORD=secret \
 3. Paginates each table in `chunkSize` batches
 4. Serializes each batch as JSONL (one JSON object per row)
 5. Compresses each batch with gzip
-6. Writes chunks to the staging location (local or MinIO)
+6. Writes chunks to the local staging location
 7. Records each staged chunk in the checkpoint ledger
 
 The checkpoint ledger lives at `.astra/checkpoints/<pipeline-name>/` by default. If a run is interrupted and restarted, already-staged chunks are skipped.
 
 ---
 
-### `execute-local-snapshot`
+### `snapshot-to-minio-staging`
 
-Run the load phase: read staged chunks and bulk-load them into the destination.
+Run the capture phase and write compressed JSONL.gz chunks to a MinIO (or S3-compatible) bucket.
 
 ```bash
-cargo run -p astra -- execute-local-snapshot <spec-file>
+cargo run -p astra -- snapshot-to-minio-staging <spec-file> [options]
 ```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--max-rows-per-table <N>` | Stop after capturing N rows per table. |
+| `--endpoint <URL>` | MinIO/S3 endpoint URL (e.g. `http://localhost:9000`). |
+| `--region <REGION>` | S3 region (default: `us-east-1`). |
+| `--access-key <KEY>` | S3 access key. |
+| `--secret-key <KEY>` | S3 secret key. |
 
 **Example:**
 
 ```bash
-POSTGRES_PASSWORD=secret \
-  cargo run -p astra -- execute-local-snapshot my-pipeline.astra.yaml
+ASTRA_SMOKE_PG_PASSWORD=astra \
+  cargo run -p astra -- snapshot-to-minio-staging examples/smoke-local-snapshot.astra.yaml \
+    --endpoint http://localhost:9000 \
+    --access-key astra \
+    --secret-key astrastorage
+```
+
+---
+
+### `load-local-staging-to-postgres`
+
+Run the load phase: read staged JSONL.gz chunks from local storage and bulk-load them into the destination Postgres database.
+
+```bash
+cargo run -p astra -- load-local-staging-to-postgres <spec-file> [options]
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--staging-root <PATH>` | Override the local staging root directory. |
+| `--control-plane-url <URL>` | Control plane URL for recording run metadata. |
+
+**Example:**
+
+```bash
+ASTRA_SMOKE_PG_PASSWORD=astra \
+  cargo run -p astra -- load-local-staging-to-postgres examples/smoke-local-snapshot.astra.yaml
+```
+
+---
+
+### `execute-local-snapshot`
+
+Run the full snapshot pipeline end-to-end: capture to local staging, then load to destination. Equivalent to running `snapshot-to-local-staging` followed by `load-local-staging-to-postgres`.
+
+```bash
+cargo run -p astra -- execute-local-snapshot <spec-file> [options]
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--no-resume` | Ignore existing checkpoints and restart from scratch. |
+| `--max-rows-per-table <N>` | Stop after capturing N rows per table. |
+| `--staging-root <PATH>` | Override the local staging root directory. |
+| `--checkpoint-root <PATH>` | Override the checkpoint ledger root directory. |
+| `--chunk-size <N>` | Override the chunk size from the spec. |
+| `--control-plane-url <URL>` | Control plane URL for recording run metadata. |
+
+**Example:**
+
+```bash
+ASTRA_SMOKE_PG_PASSWORD=astra \
+  cargo run -p astra -- execute-local-snapshot examples/smoke-local-snapshot.astra.yaml
 ```
 
 **What it does:**
 
-1. Reads the checkpoint ledger to find all staged chunks
-2. Decompresses each chunk
-3. Parses JSONL rows
-4. Bulk-inserts into `astra_raw.<table>` in the destination Postgres database
+1. Reads the checkpoint ledger to find already-staged chunks (skips them unless `--no-resume`)
+2. Paginates the source database and stages chunks to local storage
+3. Decompresses each staged chunk
+4. Parses JSONL rows
+5. Bulk-inserts into `astra_raw.<table>` in the destination Postgres database
 
 The destination tables are created automatically if they don't exist. Each row in `astra_raw` has:
 
 | Column | Type | Description |
 |---|---|---|
-| `_object_key` | `TEXT` | Source staging object key |
 | `_sequence` | `BIGINT` | Chunk sequence number |
-| `_row_number` | `BIGINT` | Row position within the chunk |
 | `_loaded_at` | `TIMESTAMPTZ` | Timestamp when the row was loaded |
 | `_data` | `JSONB` | The full source row as a JSON object |
-
----
-
-### `run-pipeline`
-
-Trigger a pipeline run via the control-plane API (requires a running control plane).
-
-```bash
-cargo run -p astra -- run-pipeline <pipeline-name>
-```
-
-**Example:**
-
-```bash
-cargo run -p astra -- run-pipeline smoke-local-snapshot
-```
-
----
-
-### `apply-spec`
-
-Register or update a pipeline spec via the control-plane API.
-
-```bash
-cargo run -p astra -- apply-spec <spec-file>
-```
-
-**Example:**
-
-```bash
-cargo run -p astra -- apply-spec my-pipeline.astra.yaml
-```
-
-Equivalent to `POST /api/v1/specs/apply`. The control plane must be running and reachable at `ASTRA_CONTROL_PLANE_ADDR` (default `127.0.0.1:8080`).
 
 ---
 
@@ -165,8 +216,7 @@ The CLI reads these variables at runtime:
 
 | Variable | Used by | Description |
 |---|---|---|
-| `env:<VAR>` | YAML spec | Any variable referenced via `env:` in a spec |
-| `ASTRA_CONTROL_PLANE_ADDR` | `run-pipeline`, `apply-spec` | Address of the control plane (default `127.0.0.1:8080`) |
+| `env:<VAR>` | YAML spec | Any variable referenced via `env:` in a spec's `passwordRef` field |
 | `ASTRA_STAGING_LOCAL_ROOT` | staging | Root directory for local staging |
 | `ASTRA_CHECKPOINT_LOCAL_ROOT` | checkpointing | Root directory for checkpoint ledgers |
 | `ASTRA_S3_ENDPOINT` | MinIO/S3 staging | S3 endpoint URL |

--- a/website/docs/connectors/overview.md
+++ b/website/docs/connectors/overview.md
@@ -27,27 +27,18 @@ Community and long-tail connectors will run as bounded subprocesses (Python 3). 
 
 The Python runtime (`crates/astra-python-runtime`) is scaffolded but not yet implemented. Connector manifests and the subprocess protocol are defined in `crates/astra-saas-sdk`.
 
-## Connector interface
+## How connectors are structured
 
-Every source connector implements the `SourceConnector` trait:
+The Postgres source is implemented as `PostgresSource` in `crates/astra-connectors`. Key methods:
 
-```rust
-// crates/astra-connectors
-pub trait SourceConnector {
-    async fn discover(&self, config: &SourceConfig) -> Result<Schema>;
-    async fn snapshot(&self, config: &SourceConfig, stream: &StreamConfig)
-        -> Result<impl Stream<Item = Result<RecordBatch>>>;
-}
-```
+- `from_spec(spec: &AstraSpec)` — constructs the connector from a parsed YAML spec
+- `discover()` — queries the source database and returns the schema of all captured tables
+- `snapshot_to_jsonl_gzip()` — paginates rows and writes compressed JSONL.gz chunks to staging
 
-Every destination connector implements the `DestinationConnector` trait:
+The Postgres destination is implemented as `PostgresDestinationLoader`. Key methods:
 
-```rust
-pub trait DestinationConnector {
-    async fn load(&self, config: &DestinationConfig, chunks: impl Iterator<Item = StagedChunk>)
-        -> Result<LoadResult>;
-}
-```
+- `from_spec(spec: &AstraSpec)` — constructs the loader from a parsed YAML spec
+- `load_local_stage_chunks()` — reads staged JSONL.gz chunks and bulk-inserts them into `astra_raw`
 
 ## Staging format
 
@@ -55,7 +46,17 @@ Between capture and load, data is stored as compressed JSONL:
 
 - One JSON object per row
 - Compressed with gzip
-- Chunks named `<sequence>.jsonl.gz`
-- Stored at `pipelines/<name>/streams/<stream>/partitions/<partition>/chunks/<seq>.jsonl.gz`
+- Sequence number zero-padded to 20 digits
+- Stored at the following path:
+
+```
+pipelines/<pipeline_name>/streams/<stream_name>/partitions/<partition_key>/chunks/<sequence:020>.jsonl.gz
+```
+
+**Example:**
+
+```
+pipelines/smoke-local-snapshot/streams/public.smoke_users/partitions/default/chunks/00000000000000000001.jsonl.gz
+```
 
 See [Staging Contract →](../architecture/staging-contract.md) for the full spec.

--- a/website/docs/connectors/postgres.md
+++ b/website/docs/connectors/postgres.md
@@ -12,18 +12,20 @@ The Postgres connector is Astra's first and most complete connector. It supports
 
 ### Connection
 
-Specify the Postgres source in your pipeline YAML:
+Specify the Postgres source in your pipeline YAML using the flat-map connection format:
 
 ```yaml
 source:
   kind: postgres
-  connection: "localhost:5432/mydb"
-  credentials:
-    user: myuser
-    password: "env:POSTGRES_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: mydb
+    username: myuser
+    passwordRef: "env:POSTGRES_PASSWORD"
 ```
 
-The connection string format is `host:port/database`. IPv6 addresses and Unix sockets are not yet supported.
+All fields are required. `passwordRef` accepts a plain string (dev only) or `env:VAR_NAME` to read from an environment variable.
 
 ### Schema discovery
 
@@ -31,7 +33,7 @@ The connection string format is `host:port/database`. IPv6 addresses and Unix so
 cargo run -p astra -- discover-source my-pipeline.astra.yaml
 ```
 
-The connector issues `SELECT column_name, data_type, is_nullable FROM information_schema.columns` queries to enumerate tables and their schemas. Primary keys are discovered via `information_schema.table_constraints`.
+The connector queries `information_schema.columns` to enumerate tables and their schemas. Primary keys are discovered via the Postgres system catalog (`pg_index`, `pg_class`, and `pg_attribute`), which is more reliable than `information_schema.table_constraints` for inherited tables and expression indexes.
 
 ### Snapshot modes
 
@@ -46,7 +48,7 @@ capture:
     chunkSize: 50000
 ```
 
-The connector uses `SELECT * FROM <table> ORDER BY <primary_key> LIMIT <chunkSize> OFFSET <n>` pagination. Each chunk is committed to staging before advancing to the next.
+The connector paginates using `SELECT to_jsonb(snapshot_row) AS record FROM (...) LIMIT <chunkSize> OFFSET <n>`. Each chunk is committed to staging before advancing to the next.
 
 #### Incremental snapshot
 
@@ -68,7 +70,7 @@ Incremental mode misses hard-deletes. Use CDC mode (not yet implemented) for ful
 
 ### Supported data types
 
-The Postgres connector maps source types to JSON as follows:
+The Postgres connector serializes rows using `to_jsonb()`, which maps source types to JSON as follows:
 
 | Postgres type | JSON representation |
 |---|---|
@@ -86,17 +88,23 @@ The Postgres connector maps source types to JSON as follows:
 
 ## Destination: Postgres (raw loader)
 
-The Postgres destination loads staged chunks into a `astra_raw` schema. This is an append-only raw layer — no deduplication or merge is performed in v0.1.
+The Postgres destination loads staged chunks into an `astra_raw` schema. This is an append-only raw layer — no deduplication or merge is performed in v0.1.
 
 ### Configuration
 
 ```yaml
 destination:
   kind: postgres
-  connection: "localhost:5432/warehouse"
-  credentials:
-    user: warehouse_user
-    password: "env:WAREHOUSE_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: warehouse
+    username: warehouse_user
+    passwordRef: "env:WAREHOUSE_PASSWORD"
+    schema: astra_raw          # optional, defaults to astra_raw
+    tablePrefix: raw_          # optional, defaults to raw_
+    applicationName: astra-loader  # optional
+    sslMode: prefer            # optional
   staging:
     kind: local
     bucket: astra-staging
@@ -108,35 +116,36 @@ destination:
 
 ### Raw table schema
 
-For each source table `<schema>.<table>`, Astra creates `astra_raw.raw_<schema>_<table>`:
+For each source table `<schema>.<table>`, Astra creates `<destination_schema>.<tablePrefix><schema>_<table>`. With defaults this becomes `astra_raw.raw_public_users`:
 
 ```sql
 CREATE TABLE astra_raw.raw_public_users (
-    _object_key   TEXT          NOT NULL,
     _sequence     BIGINT        NOT NULL,
-    _row_number   BIGINT        NOT NULL,
     _loaded_at    TIMESTAMPTZ   NOT NULL DEFAULT now(),
     _data         JSONB         NOT NULL
 );
 ```
 
-- `_object_key` — the staging object key for the source chunk
 - `_sequence` — chunk sequence number (monotonically increasing within a run)
-- `_row_number` — row position within the chunk
+- `_loaded_at` — timestamp when the row was loaded
 - `_data` — the full source row as a JSON object
 
 ### Applied chunks tracking
 
-To prevent double-loading, the destination tracks which chunks have been applied:
+To prevent double-loading, the destination tracks which chunks have been applied in `astra_raw._applied_chunks`:
 
 ```sql
 CREATE TABLE astra_raw._applied_chunks (
-    object_key   TEXT PRIMARY KEY,
-    applied_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    pipeline_name  TEXT        NOT NULL,
+    stream_name    TEXT        NOT NULL,
+    sequence       BIGINT      NOT NULL,
+    row_count      BIGINT,
+    loaded_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (pipeline_name, stream_name, sequence)
 );
 ```
 
-Re-running `execute-local-snapshot` skips already-applied chunks.
+Each chunk load is wrapped in a transaction with `INSERT INTO _applied_chunks ... ON CONFLICT DO NOTHING`. Re-running `execute-local-snapshot` (or `load-local-staging-to-postgres`) skips already-applied chunks, making the load phase idempotent.
 
 ### CDC (planned)
 

--- a/website/docs/control-plane/api.md
+++ b/website/docs/control-plane/api.md
@@ -23,6 +23,26 @@ Default bind address: `127.0.0.1:8080`. Override with `ASTRA_CONTROL_PLANE_ADDR`
 
 ---
 
+## Health and meta
+
+### `GET /`
+
+Returns a welcome message. Used to verify the server is up.
+
+### `GET /health`
+
+Health check endpoint.
+
+### `GET /ready`
+
+Readiness check — returns 200 when the server is ready to handle requests.
+
+### `GET /version`
+
+Returns the server version string.
+
+---
+
 ## Pipelines
 
 ### `GET /api/v1/pipelines`
@@ -34,7 +54,6 @@ List all registered pipelines.
 ```json
 [
   {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
     "name": "smoke-local-snapshot",
     "status": "active",
     "mode": "snapshot",
@@ -45,63 +64,25 @@ List all registered pipelines.
 ]
 ```
 
-### `GET /api/v1/pipelines/:id`
+### `GET /api/v1/pipelines/:pipeline_name`
 
-Get a single pipeline by ID.
+Get the YAML spec for a single pipeline by name.
 
-### `POST /api/v1/pipelines`
-
-Create a new pipeline (without applying a YAML spec). Prefer `/api/v1/specs/apply` for YAML-driven workflows.
-
-**Body:**
-
-```json
-{
-  "name": "my-pipeline",
-  "mode": "snapshot",
-  "schedule": "manual",
-  "spec_json": { ... }
-}
-```
-
-### `DELETE /api/v1/pipelines/:id`
+### `DELETE /api/v1/pipelines/:pipeline_name`
 
 Delete a pipeline and its associated metadata.
 
----
+### `POST /api/v1/pipelines/:pipeline_name/disable`
 
-## Pipeline Runs
+Disable a pipeline. Disabled pipelines will not be triggered by the scheduler.
 
-### `GET /api/v1/pipeline-runs`
+### `POST /api/v1/pipelines/:pipeline_name/enable`
 
-List all pipeline runs across all pipelines.
+Re-enable a previously disabled pipeline.
 
-**Response:**
+### `POST /api/v1/pipelines/:pipeline_name/trigger`
 
-```json
-[
-  {
-    "id": "7b7b7b7b-7b7b-7b7b-7b7b-7b7b7b7b7b7b",
-    "pipeline_id": "550e8400-e29b-41d4-a716-446655440000",
-    "pipeline_name": "smoke-local-snapshot",
-    "status": "completed",
-    "started_at": "2024-01-15T10:05:00Z",
-    "completed_at": "2024-01-15T10:05:42Z"
-  }
-]
-```
-
-### `GET /api/v1/pipeline-runs/:id`
-
-Get a single run by ID.
-
-### `GET /api/v1/pipelines/:id/runs`
-
-List all runs for a specific pipeline.
-
-### `POST /api/v1/pipelines/:id/runs`
-
-Trigger a new run for a pipeline. The run is executed inline (embedded executor).
+Trigger a new run for a pipeline. The run is executed inline (embedded executor, spawned via `tokio::spawn`).
 
 **Body:** Empty or `{}`
 
@@ -114,9 +95,57 @@ Trigger a new run for a pipeline. The run is executed inline (embedded executor)
 }
 ```
 
+### `GET /api/v1/pipelines/:pipeline_name/runs`
+
+List all runs for a specific pipeline.
+
+### `GET /api/v1/pipelines/:pipeline_name/latest-run`
+
+Get the most recent run for a pipeline.
+
+### `GET /api/v1/pipelines/:pipeline_name/run-history`
+
+Get the full run history for a pipeline, ordered by start time.
+
+---
+
+## Pipeline Runs
+
+### `POST /api/v1/pipeline-runs`
+
+Create a new pipeline run record (used internally by the executor to register a run before it starts).
+
+### `POST /api/v1/pipeline-runs/:run_id/status`
+
+Update the status of a pipeline run (e.g., mark as completed or failed).
+
+### `POST /api/v1/pipeline-runs/:run_id/artifacts`
+
+Record a staged artifact (chunk) for a run.
+
+**Body:**
+
+```json
+{
+  "pipeline_name": "smoke-local-snapshot",
+  "stream_name": "public.smoke_users",
+  "sequence": 1,
+  "object_key": "pipelines/smoke-local-snapshot/streams/public.smoke_users/...",
+  "row_count": 1000
+}
+```
+
+### `GET /api/v1/pipeline-runs/:run_id/artifacts`
+
+List all staged artifacts recorded for a run.
+
+### `POST /api/v1/pipeline-runs/:run_id/table-executions`
+
+Upsert a table-level execution record for a run. Tracks per-table status, row counts, and timing.
+
 ### `GET /api/v1/pipeline-runs/:run_id/table-executions`
 
-List all table-level execution records for a run. Each entry tracks the status of one table within the run.
+List all table-level execution records for a run.
 
 **Response:**
 
@@ -147,16 +176,18 @@ Parse, validate, and register a pipeline from a YAML spec string. Creates the pi
 
 ```json
 {
-  "spec": "version: v1alpha1\npipeline:\n  name: my-pipeline\n  ..."
+  "yaml": "version: v1alpha1\npipeline:\n  name: my-pipeline\n  ...",
+  "created_by": "alice"
 }
 ```
+
+The `created_by` field is optional.
 
 **Response (success):**
 
 ```json
 {
-  "pipeline_id": "550e8400-...",
-  "name": "my-pipeline",
+  "pipeline_name": "my-pipeline",
   "created": true
 }
 ```
@@ -169,6 +200,14 @@ Parse, validate, and register a pipeline from a YAML spec string. Creates the pi
   "details": ["pipeline.name is required", "source.kind must be one of: postgres"]
 }
 ```
+
+---
+
+## Examples
+
+### `GET /api/v1/examples/postgres-to-warehouse`
+
+Returns a pre-built example YAML spec for a Postgres-to-warehouse pipeline. Used by the YAML Studio in the web UI to populate a starter template.
 
 ---
 

--- a/website/docs/development/crate-guide.md
+++ b/website/docs/development/crate-guide.md
@@ -24,13 +24,13 @@ The main server binary. Responsibilities:
 Key types:
 - `PipelineService` — orchestrates create/read/update for pipelines and runs
 - `PostgresPipelineRepository` / `InMemoryPipelineRepository`
-- API handlers in `src/api/`
+- API handlers in `src/http/`
 
 ### `apps/cli`
 
 The `astra` CLI binary. Built with [Clap](https://docs.rs/clap).
 
-Commands: `validate`, `discover-source`, `snapshot-to-local-staging`, `execute-local-snapshot`, `run-pipeline`, `apply-spec`.
+Commands: `validate`, `apply`, `discover-source`, `snapshot-to-local-staging`, `snapshot-to-minio-staging`, `load-local-staging-to-postgres`, `execute-local-snapshot`.
 
 ### `apps/web`
 
@@ -49,9 +49,9 @@ Stub for a future distributed worker that executes pipeline runs on behalf of th
 YAML spec parsing and validation for the `v1alpha1` pipeline spec.
 
 Key types:
-- `PipelineSpec` — top-level spec struct (derives `serde::Deserialize`)
-- `SourceConfig`, `DestinationConfig`, `RuntimeConfig`
-- `validate(spec: &PipelineSpec) -> Result<(), Vec<ValidationError>>`
+- `AstraSpec` — top-level spec struct (derives `serde::Deserialize`)
+- `Source`, `Destination`, `Runtime`, `Capture`, `Pipeline`
+- `validate(spec: &AstraSpec) -> Result<(), Vec<String>>` — returns a list of validation error messages
 
 Depended on by: `apps/control-plane`, `apps/cli`
 
@@ -59,7 +59,7 @@ Depended on by: `apps/control-plane`, `apps/cli`
 
 Shared enums and domain types used across the workspace:
 
-- `PipelineStatus` — `Active`, `Paused`, `Error`
+- `PipelineStatus` — `Draft`, `Active`, `Disabled`, `Paused`, `Failed`, `Archived`
 - `RunStatus` — `Started`, `Completed`, `Failed`
 - `JobKind` — `Snapshot`, `Incremental`, `Cdc`
 - `RunPhase` — `Capture`, `Load`, `Done`
@@ -71,25 +71,31 @@ Depended on by: all crates that deal with pipeline state.
 Staging backends and checkpoint logic. The core durability layer.
 
 Key types:
-- `StagingBackend` trait — `write_chunk`, `read_chunk`, `list_chunks`
-- `LocalStagingBackend` — writes to the local filesystem
-- `MinioStagingBackend` / `S3StagingBackend` — writes to object storage
-- `CheckpointLedger` — reads/writes checkpoint state
-- `StageChunk` — chunk metadata struct
+- `StageChunkStore` async trait — `ensure_ready`, `write_chunk`, `read_chunk`
+- `LocalStageChunkStore` — writes to the local filesystem; also exposes `list_chunks_for_pipeline()`
+- `MinioStageChunkStore` — writes to MinIO or S3-compatible storage via the `object_store` crate
+- `SnapshotCheckpointLedger` / `LocalCheckpointStore` — reads/writes per-pipeline checkpoint state as JSON
+- `StageChunk` — chunk metadata struct (pipeline, stream, partition, sequence, row_count, object_key)
+
+Staging object keys follow this convention:
+
+```
+pipelines/<pipeline_name>/streams/<stream_name>/partitions/<partition_key>/chunks/<sequence:020>.jsonl.gz
+```
 
 ### `crates/astra-connectors`
 
 Source and destination connector implementations.
 
 Key types:
-- `PostgresSourceConnector` — `discover()`, `snapshot()`, `snapshot_incremental()`
-- `PostgresDestinationConnector` — `load_chunks()`
+- `PostgresSource` — `from_spec()`, `discover()`, `snapshot_to_jsonl_gzip()`
+- `PostgresDestinationLoader` — `from_spec()`, `load_local_stage_chunks()`
 
-The Postgres destination creates and populates `astra_raw.<table>` tables.
+The Postgres source uses `to_jsonb()` for row serialization and system catalog queries for PK discovery. The Postgres destination creates and populates `astra_raw.<table>` tables with per-chunk idempotency tracking via `_applied_chunks`.
 
 ### `crates/astra-cdc`
 
-CDC orchestration. Currently a stub that returns an explicit "not implemented" error when triggered.
+CDC orchestration. Currently a stub — defines `CdcPhase`, `PostgresConfig`, `CdcConfig`, and `StreamProgress` types, but `status()` returns `"cdc skeleton defined"`. Returns an explicit "not implemented" error when triggered via the CLI.
 
 Planned: Postgres logical replication via `pgoutput`, WAL position tracking, initial backfill + tail mode.
 
@@ -99,15 +105,11 @@ Core domain value objects shared across the workspace. Small types that don't be
 
 ### `crates/astra-api`
 
-HTTP API client types for the control-plane API. Used by the CLI commands that talk to the control plane (`run-pipeline`, `apply-spec`).
+HTTP API client types for the control-plane API. Used by CLI commands that communicate with the control plane.
 
 ### `crates/astra-secrets`
 
-Credential management abstraction. Currently supports `env:<VAR>` secret references. Vault and file-based secrets are planned.
-
-Key types:
-- `SecretResolver` trait
-- `EnvSecretResolver` — resolves `env:VAR` to environment variable values
+Credential management abstraction. Currently a stub — `status()` returns a string. The `env:` prefix for `passwordRef` is resolved directly in `crates/astra-connectors` without going through this crate. Vault and file-based secrets are planned.
 
 ### `crates/astra-observability`
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -8,6 +8,15 @@ sidebar_position: 1
 
 Get Astra running and replicate your first table in about 15 minutes.
 
+There are two ways to run a pipeline:
+
+- **[Path A — CLI](#path-a-cli)**: run commands directly from the terminal. Good for scripting, CI, or if you just want to try things out without starting a server.
+- **[Path B — Web UI](#path-b-web-ui)**: start the control plane, register your pipeline through the YAML Studio, and trigger runs from the dashboard. Good for an interactive workflow.
+
+Both paths start with the same setup steps below.
+
+---
+
 ## Prerequisites
 
 - **Rust** — install via [rustup](https://rustup.rs) (`stable` toolchain)
@@ -15,7 +24,11 @@ Get Astra running and replicate your first table in about 15 minutes.
 - **Python 3.8+** — for smoke tests (optional)
 - **Git**
 
-## 1. Clone and build
+---
+
+## Shared setup
+
+### 1. Clone and build
 
 ```bash
 git clone https://github.com/suryachereddy/Astra.git
@@ -25,9 +38,9 @@ cargo build
 
 The workspace builds all crates and binaries in one pass. First build takes a few minutes.
 
-## 2. Start local infrastructure
+### 2. Start local infrastructure
 
-Astra needs Postgres (metadata) and MinIO (staging) locally. Both are in the provided Docker Compose file:
+Astra needs Postgres (metadata and source/destination) and MinIO (staging) locally. Both are in the provided Docker Compose file:
 
 ```bash
 podman compose -f deploy/docker-compose/docker-compose.yml up -d
@@ -44,9 +57,9 @@ Verify both are up:
 podman compose -f deploy/docker-compose/docker-compose.yml ps
 ```
 
-## 3. Seed test data
+### 3. Seed test data
 
-Create tables in the local Postgres database to replicate from:
+Create a table in the local Postgres database to replicate from:
 
 ```bash
 PGPASSWORD=astra psql -h localhost -U astra -d astra -c "
@@ -62,66 +75,188 @@ PGPASSWORD=astra psql -h localhost -U astra -d astra -c "
 "
 ```
 
-## 4. Validate your pipeline spec
+---
 
-The example pipeline replicates `public.smoke_users` from Postgres back to the same Postgres instance (useful for local testing):
+## Path A: CLI
+
+No server required. The CLI handles capture and load directly.
+
+### 4. Validate the spec
+
+The example pipeline replicates `public.smoke_users` from Postgres back to the same instance using local file staging:
 
 ```bash
 cargo run -p astra -- validate examples/smoke-local-snapshot.astra.yaml
 ```
 
-Expected output: `Pipeline spec is valid.`
-
-## 5. Discover the source schema
-
-```bash
-cargo run -p astra -- discover-source examples/smoke-local-snapshot.astra.yaml
+Expected output:
+```
+valid Astra spec: smoke-local-snapshot  mode=snapshot  source=postgres  dest=postgres  tables=[...]
 ```
 
-This connects to the source database and prints the discovered tables with their column types.
+Exits with code 0 on success. Validation errors are printed to stderr.
 
-## 6. Run the snapshot
+### 5. Discover the source schema
 
 ```bash
 ASTRA_SMOKE_PG_PASSWORD=astra \
-cargo run -p astra -- snapshot-to-local-staging examples/smoke-local-snapshot.astra.yaml
+  cargo run -p astra -- discover-source examples/smoke-local-snapshot.astra.yaml
 ```
 
-Astra paginates through `smoke_users` in chunks of 1,000 rows, compresses each chunk to JSONL.gz, and writes them to the local staging directory. You'll see progress logged to stdout.
+Connects to the source database and prints each table's column names, types, nullability, and primary keys. Useful for building or verifying the `capture.tables` list in your spec.
 
-## 7. Load to the destination
+### 6. Run the full snapshot (capture + load)
 
 ```bash
 ASTRA_SMOKE_PG_PASSWORD=astra \
-cargo run -p astra -- execute-local-snapshot examples/smoke-local-snapshot.astra.yaml
+  cargo run -p astra -- execute-local-snapshot examples/smoke-local-snapshot.astra.yaml
 ```
 
-This reads the staged chunks and bulk-loads them into the `astra_raw` schema of the destination database. Check the result:
+This runs both phases in sequence:
+
+1. **Capture** — paginates `smoke_users` in chunks of 1,000 rows, compresses each chunk to JSONL.gz, writes to local staging, and records progress in the checkpoint ledger.
+2. **Load** — reads the staged chunks and bulk-inserts into `astra_raw.raw_public_smoke_users` in the destination database.
+
+You'll see per-chunk progress logged to stdout. If the run is interrupted, re-running the same command resumes from the last checkpoint. Pass `--no-resume` to restart from scratch.
+
+### 7. Verify the result
 
 ```bash
-PGPASSWORD=astra psql -h localhost -U astra -d astra -c "
-  SELECT count(*) FROM astra_raw.raw_public_smoke_users;
-"
+PGPASSWORD=astra psql -h localhost -U astra -d astra \
+  -c "SELECT count(*) FROM astra_raw.raw_public_smoke_users;"
+```
+
+You should see 500 rows. Each row has a `_data` JSONB column containing the original source record and metadata columns `_sequence` and `_loaded_at`.
+
+---
+
+## Path B: Web UI
+
+The web UI lets you register pipelines through a YAML editor, trigger runs with one click, and inspect run history and per-table results.
+
+### 4. Start the control plane
+
+```bash
+ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra \
+  cargo run -p astra-control-plane
+```
+
+The control plane binds to `127.0.0.1:8080` by default. It serves both the REST API and the embedded React web UI.
+
+Open [http://127.0.0.1:8080](http://127.0.0.1:8080) — you should see the pipeline dashboard (empty for now).
+
+### 5. Register a pipeline via YAML Studio
+
+1. Click **YAML Studio** in the navigation.
+2. Click **Load example** — this pre-fills the editor with the `postgres-to-warehouse` starter spec from the API.
+3. Replace the contents with the smoke test spec below (or paste your own):
+
+```yaml
+version: v1alpha1
+pipeline:
+  name: smoke-local-snapshot
+  mode: snapshot
+  schedule: manual
+source:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:ASTRA_SMOKE_PG_PASSWORD
+  capture:
+    tables:
+      - public.smoke_users
+    snapshot:
+      mode: full
+      chunkSize: 1000
+destination:
+  kind: postgres
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:ASTRA_SMOKE_PG_PASSWORD
+    schema: astra_raw
+    tablePrefix: raw_
+  staging:
+    kind: local
+    bucket: astra-smoke-staging
+    prefix: smoke-local-snapshot/
+  write:
+    mode: append
+    batchSize: 10000
+runtime:
+  parallelism:
+    tables: 1
+  checkpointing:
+    intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause
+```
+
+4. Click **Apply** — this calls `POST /api/v1/specs/apply`, validates the spec, and registers the pipeline. You should see a success confirmation.
+
+### 6. View the pipeline in the dashboard
+
+Navigate back to the **Overview** page. Your `smoke-local-snapshot` pipeline now appears in the list with status `active`.
+
+From the pipeline card you can:
+- **Enable / Disable** — disable stops the scheduler from triggering runs automatically.
+- **Trigger** — manually kick off a run immediately (see next step).
+- **Delete** — removes the pipeline and its metadata.
+
+### 7. Trigger a run
+
+Click **Trigger** on the `smoke-local-snapshot` pipeline card. The control plane spawns the pipeline executor inline and the run begins.
+
+:::note
+The executor needs the `ASTRA_SMOKE_PG_PASSWORD` environment variable to be set in the shell where the control plane is running — it reads secrets from the environment at execution time. Make sure you started the control plane with that variable exported:
+
+```bash
+ASTRA_SMOKE_PG_PASSWORD=astra \
+ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra \
+  cargo run -p astra-control-plane
+```
+:::
+
+### 8. Inspect run history and table results
+
+Click the pipeline name to open its detail page. You will see:
+
+**Run History** — a chronological list of runs showing:
+- Run ID and trigger time
+- Duration
+- Status (`started` / `completed` / `failed`)
+
+Click any run to drill down into **Table Executions**:
+- Table name
+- Rows captured and chunks staged
+- Per-table status and start/end timestamps
+
+This is especially useful for multi-table pipelines where one table might fail while others succeed.
+
+### 9. Verify the result
+
+```bash
+PGPASSWORD=astra psql -h localhost -U astra -d astra \
+  -c "SELECT count(*) FROM astra_raw.raw_public_smoke_users;"
 ```
 
 You should see 500 rows.
 
-## 8. Start the control plane (optional)
+---
 
-The control plane exposes a REST API and serves the web UI:
-
-```bash
-ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra \
-cargo run -p astra-control-plane
-```
-
-Open [http://127.0.0.1:8080](http://127.0.0.1:8080) to see the web UI.
-
-## 9. Run smoke tests (optional)
+## Optional: run smoke tests
 
 ```bash
 python3 scripts/yaml_contract_smoke.py
 ```
+
+---
 
 ## What's next?
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -30,14 +30,14 @@ Pipelines are defined in YAML (`v1alpha1` spec) and executed via the CLI or the 
 
 ## What's in v0.1
 
-**Working**: YAML validation, Postgres schema discovery, full and incremental snapshot, local/MinIO staging (JSONL.gz), Postgres raw destination loader, resumable checkpoint ledger, 6 CLI commands, control-plane REST API (10 endpoints), React web UI.
+**Working**: YAML validation, Postgres schema discovery, full and incremental snapshot, local/MinIO/S3 staging (JSONL.gz), Postgres raw destination loader, resumable checkpoint ledger, 7 CLI commands, control-plane REST API (17+ endpoints), React web UI with pipeline dashboard, run history, and YAML Studio.
 
-**Not yet implemented**: CDC execution (stub), Python connector runtime, Snowflake/BigQuery destinations, merge/upsert write mode, schema evolution enforcement, distributed workers, observability.
+**Not yet implemented**: CDC execution (stub), Python connector runtime, Snowflake/BigQuery destinations, merge/upsert/replace write modes, schema evolution enforcement, distributed workers, observability.
 
 ## Quick navigation
 
 - [Quickstart →](./getting-started/quickstart.md) — up and running in 15 minutes
 - [YAML Spec →](./yaml-spec/overview.md) — full pipeline spec reference
-- [CLI Reference →](./cli/reference.md) — all six commands documented
+- [CLI Reference →](./cli/reference.md) — all seven commands documented
 - [API Reference →](./control-plane/api.md) — REST API for the control plane
 - [Architecture →](./architecture/overview.md) — design decisions and data flow

--- a/website/docs/yaml-spec/examples.md
+++ b/website/docs/yaml-spec/examples.md
@@ -12,18 +12,18 @@ The minimal example used by the e2e smoke test. Replicates two tables from a loc
 
 ```yaml title="examples/smoke-local-snapshot.astra.yaml"
 version: v1alpha1
-
 pipeline:
   name: smoke-local-snapshot
   mode: snapshot
   schedule: manual
-
 source:
   kind: postgres
-  connection: "localhost:5432/astra"
-  credentials:
-    user: astra
-    password: "env:ASTRA_SMOKE_PG_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:ASTRA_SMOKE_PG_PASSWORD
   capture:
     tables:
       - public.smoke_users
@@ -31,13 +31,17 @@ source:
     snapshot:
       mode: full
       chunkSize: 1000
-
 destination:
   kind: postgres
-  connection: "localhost:5432/astra"
-  credentials:
-    user: astra
-    password: "env:ASTRA_SMOKE_PG_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: astra
+    username: astra
+    passwordRef: env:ASTRA_SMOKE_PG_PASSWORD
+    schema: astra_raw
+    tablePrefix: raw_
+    applicationName: astra-smoke-loader
   staging:
     kind: local
     bucket: astra-smoke-staging
@@ -45,12 +49,14 @@ destination:
   write:
     mode: append
     batchSize: 10000
-
 runtime:
   parallelism:
     tables: 1
   checkpointing:
     intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause
 ```
 
 **Run it:**
@@ -65,39 +71,42 @@ ASTRA_SMOKE_PG_PASSWORD=astra \
 
 ---
 
-## Incremental snapshot (Postgres → Postgres)
+## Full snapshot (Postgres → Postgres, cross-instance)
 
-Uses a cursor field (`updated_at`) so only rows modified since the last run are captured. Ideal for large tables that grow over time.
+Replicates two tables from an application Postgres instance to a separate warehouse instance using local file staging.
 
 ```yaml title="examples/postgres-to-postgres-raw.astra.yaml"
 version: v1alpha1
-
 pipeline:
   name: postgres-raw-local
   mode: snapshot
   schedule: manual
-
 source:
   kind: postgres
-  connection: "localhost:5432/app"
-  credentials:
-    user: app_user
-    password: "env:POSTGRES_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
   capture:
     tables:
       - public.users
       - public.orders
     snapshot:
-      mode: incremental
-      cursorField: updated_at
+      mode: full
       chunkSize: 50000
-
 destination:
   kind: postgres
-  connection: "localhost:5432/warehouse"
-  credentials:
-    user: warehouse_user
-    password: "env:WAREHOUSE_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: warehouse
+    username: warehouse_user
+    passwordRef: env:WAREHOUSE_PASSWORD
+    schema: astra_raw
+    tablePrefix: raw_
+    applicationName: astra-loader
   staging:
     kind: local
     bucket: astra-staging
@@ -105,38 +114,40 @@ destination:
   write:
     mode: append
     batchSize: 100000
-
 runtime:
   parallelism:
     tables: 2
   checkpointing:
     intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause
 ```
 
 ---
 
-## Hourly sync to data warehouse (Postgres → Snowflake)
+## Hourly incremental sync to data warehouse (Postgres → Snowflake)
 
-Production-grade pattern: hourly cron, incremental snapshot, S3 staging, and merge write mode for idempotent upserts.
+Production-grade pattern: hourly cron, incremental snapshot using a cursor field, S3 staging, and merge write mode for idempotent upserts.
 
 :::note
-Snowflake destination and merge write mode are parsed and validated but not yet implemented in v0.1. This example shows the target spec shape.
+The Snowflake destination and `merge` write mode are parsed and validated by the spec parser, but are not yet executed in v0.1. This example shows the target spec shape for when these features are implemented.
 :::
 
 ```yaml title="examples/postgres-to-warehouse.astra.yaml"
 version: v1alpha1
-
 pipeline:
   name: postgres-analytics
   mode: snapshot
   schedule: "0 * * * *"    # every hour
-
 source:
   kind: postgres
-  connection: "localhost:5432/app"
-  credentials:
-    user: app_user
-    password: "env:POSTGRES_PASSWORD"
+  connection:
+    host: localhost
+    port: 5432
+    database: app
+    username: app_user
+    passwordRef: env:POSTGRES_PASSWORD
   capture:
     tables:
       - public.users
@@ -145,7 +156,6 @@ source:
       mode: incremental
       cursorField: updated_at
       chunkSize: 50000
-
 destination:
   kind: snowflake
   staging:
@@ -155,12 +165,14 @@ destination:
   write:
     mode: merge
     batchSize: 100000
-
 runtime:
   parallelism:
     tables: 4
   checkpointing:
     intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply
+    breakingChanges: pause
 ```
 
 ---
@@ -172,15 +184,10 @@ Instead of using the CLI, you can register a pipeline through the control plane:
 ```bash
 curl -X POST http://127.0.0.1:8080/api/v1/specs/apply \
   -H "Content-Type: application/json" \
-  -d @apply.json
-```
-
-Where `apply.json` contains:
-
-```json
-{
-  "spec": "<yaml content as a string>"
-}
+  -d '{
+    "yaml": "version: v1alpha1\npipeline:\n  name: my-pipeline\n  ...",
+    "created_by": "alice"
+  }'
 ```
 
 Or use the web UI's **YAML Studio** to paste, validate, and apply specs interactively.

--- a/website/docs/yaml-spec/overview.md
+++ b/website/docs/yaml-spec/overview.md
@@ -17,13 +17,18 @@ pipeline:
   name: my-pipeline
   mode: snapshot          # snapshot | incremental | cdc
   schedule: manual        # manual | continuous | cron expression
+  description: "optional human-readable description"
+  labels:
+    env: production
 
 source:
   kind: postgres
-  connection: "<host>:<port>/<database>"
-  credentials:
-    user: "<username>"
-    password: "env:<ENV_VAR>"
+  connection:
+    host: localhost
+    port: 5432
+    database: mydb
+    username: myuser
+    passwordRef: "env:POSTGRES_PASSWORD"
   capture:
     tables:
       - public.users
@@ -31,19 +36,26 @@ source:
     snapshot:
       mode: full            # full | incremental
       chunkSize: 50000
+      cursorField: updated_at   # required for incremental mode
 
 destination:
-  kind: postgres            # postgres | snowflake | bigquery (future)
-  connection: "<host>:<port>/<database>"
-  credentials:
-    user: "<username>"
-    password: "env:<ENV_VAR>"
+  kind: postgres            # postgres | snowflake (parsed, not yet implemented)
+  connection:               # required for postgres destinations
+    host: localhost
+    port: 5432
+    database: warehouse
+    username: loader
+    passwordRef: "env:WAREHOUSE_PASSWORD"
+    schema: astra_raw       # optional, defaults to astra_raw
+    tablePrefix: raw_       # optional table name prefix
+    applicationName: astra-loader  # optional Postgres application_name
+    sslMode: prefer         # optional SSL mode
   staging:
     kind: local             # local | s3 | minio
     bucket: my-staging-bucket
     prefix: my-pipeline/
   write:
-    mode: append            # append | merge (future)
+    mode: append            # append | upsert | merge | replace
     batchSize: 100000
 
 runtime:
@@ -51,6 +63,9 @@ runtime:
     tables: 1               # parsed but not yet enforced in v0.1
   checkpointing:
     intervalSeconds: 30
+  schemaEvolution:
+    additiveChanges: auto-apply   # auto-apply | ignore | pause
+    breakingChanges: pause        # pause | ignore
 ```
 
 ## Fields
@@ -63,34 +78,47 @@ Always `v1alpha1`. Future versions will introduce new spec versions with migrati
 
 | Field | Required | Description |
 |---|---|---|
-| `name` | Yes | Unique pipeline identifier. Used in staging paths and API endpoints. |
+| `name` | Yes | Unique pipeline identifier. Used in staging paths and API endpoints. Must be non-empty. |
 | `mode` | Yes | `snapshot` (full table copy), `incremental` (cursor-based), or `cdc` (log-based; not yet implemented). |
 | `schedule` | Yes | `manual` (trigger only via CLI/API), `continuous` (run as soon as previous finishes), or a cron expression like `"0 * * * *"` (hourly). |
+| `description` | No | Human-readable description for display in the web UI. |
+| `labels` | No | Arbitrary string key-value pairs for tagging. |
 
 ### `source`
 
 | Field | Required | Description |
 |---|---|---|
 | `kind` | Yes | Source connector type. Currently only `postgres`. |
-| `connection` | Yes | `host:port/database` format. |
-| `credentials.user` | Yes | Database username. |
-| `credentials.password` | Yes | Plain string or `env:<VAR_NAME>` to read from environment. |
+| `connection.host` | Yes | Database hostname. |
+| `connection.port` | Yes | Database port. |
+| `connection.database` | Yes | Database name. |
+| `connection.username` | Yes | Database username. |
+| `connection.passwordRef` | Yes | Password value. Use `"env:VAR_NAME"` to read from environment, or a plain string for dev. |
 | `capture.tables` | Yes | List of `schema.table` pairs to replicate. |
 | `capture.snapshot.mode` | Yes (snapshot/incremental) | `full` — replicate all rows every run. `incremental` — only rows where `cursorField > lastCheckpoint`. |
 | `capture.snapshot.cursorField` | Yes (incremental mode) | Column used as the watermark (e.g., `updated_at`). Must be monotonically increasing. |
 | `capture.snapshot.chunkSize` | No | Rows per staged chunk. Default: `50000`. |
 
+CDC mode (`capture.cdc`) requires `slotName` and `publicationName` but is not yet executed — specifying it will produce a validation warning.
+
 ### `destination`
 
 | Field | Required | Description |
 |---|---|---|
-| `kind` | Yes | Destination connector. Currently `postgres`. `snowflake` and `bigquery` are parsed but not implemented. |
-| `connection` | Yes (postgres) | `host:port/database`. |
-| `credentials` | Yes (postgres) | Same `user` / `password` as source. |
+| `kind` | Yes | Destination connector. Currently `postgres` (implemented). `snowflake` and `bigquery` are parsed but not implemented. |
+| `connection.host` | Yes (postgres) | Database hostname. |
+| `connection.port` | Yes (postgres) | Database port. |
+| `connection.database` | Yes (postgres) | Database name. |
+| `connection.username` | Yes (postgres) | Database username. |
+| `connection.passwordRef` | Yes (postgres) | Password — same `env:` syntax as source. |
+| `connection.schema` | No | Target schema for raw tables. Defaults to `astra_raw`. |
+| `connection.tablePrefix` | No | Prefix added to each raw table name. Defaults to `raw_`. |
+| `connection.applicationName` | No | Postgres `application_name` for connection tracking. |
+| `connection.sslMode` | No | Postgres SSL mode (e.g., `prefer`, `require`, `disable`). |
 | `staging.kind` | Yes | `local`, `s3`, or `minio`. |
 | `staging.bucket` | Yes | Bucket name (or local directory name). |
 | `staging.prefix` | No | Key prefix for staged objects. |
-| `write.mode` | Yes | `append` — inserts all rows. `merge` — upsert by primary key (not yet implemented). |
+| `write.mode` | Yes | `append` inserts all rows. `upsert`, `merge`, and `replace` are parsed but not yet implemented. |
 | `write.batchSize` | No | Rows per destination batch. Default: `100000`. |
 
 ### `runtime`
@@ -99,30 +127,34 @@ Always `v1alpha1`. Future versions will introduce new spec versions with migrati
 |---|---|
 | `parallelism.tables` | Number of tables to process concurrently. Parsed but currently enforced as 1. |
 | `checkpointing.intervalSeconds` | How often to flush the checkpoint ledger during a run. |
+| `schemaEvolution.additiveChanges` | What to do when new columns are added: `auto-apply`, `ignore`, or `pause`. Parsed but not yet enforced. |
+| `schemaEvolution.breakingChanges` | What to do on breaking schema changes (column removed/renamed): `pause` or `ignore`. Parsed but not yet enforced. |
 
 ## Secret references
 
-Passwords and credentials support two forms:
+Passwords use `passwordRef` and support two forms:
 
 ```yaml
-password: "mysecretpassword"          # plain text (dev only)
-password: "env:POSTGRES_PASSWORD"     # read from environment variable
+passwordRef: "mysecretpassword"        # plain text (dev only)
+passwordRef: "env:POSTGRES_PASSWORD"   # read from environment variable
 ```
 
-Vault and file-based secrets are planned but not yet implemented.
+`file:` and `vault:` secret reference formats are recognized by the validator as valid syntax but are not yet resolved at runtime. Use `env:` for all credentials today.
 
 ## Validation rules
 
 The CLI and control-plane API validate specs before storing or executing them:
 
-- `name` must be non-empty and contain only alphanumeric characters, hyphens, and underscores
-- `mode` must be one of the allowed values
+- `name` must be non-empty
+- `mode` must be one of the allowed values (`snapshot`, `incremental`, `cdc`)
 - `schedule` must be `manual`, `continuous`, or a valid cron expression
 - `source.kind` must be a known connector type
 - `capture.tables` must be non-empty
 - `incremental` mode requires `cursorField`
+- `cdc` mode requires `slotName` and `publicationName` in `capture.cdc`
 - `staging.kind` must be one of `local`, `s3`, `minio`
-- `write.mode` must be `append` or `merge`
+- `write.mode` must be one of `append`, `upsert`, `merge`, `replace`
+- Postgres and Snowflake/BigQuery destinations require a `staging` block
 
 ## Examples
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,10 +9,10 @@ const config = {
   favicon: 'img/favicon.ico',
 
   url: 'https://astra-core.github.io',
-  baseUrl: '/',
+  baseUrl: '/Astra/',
 
   organizationName: 'astra-core',
-  projectName: 'astra-core.github.io',
+  projectName: 'Astra',
   deploymentBranch: 'gh-pages',
   trailingSlash: false,
 


### PR DESCRIPTION
## Summary

- **CLI reference**: adds the two missing commands (`snapshot-to-minio-staging`, `load-local-staging-to-postgres`), removes non-existent `run-pipeline`/`apply-spec`, documents all flags, fixes the `validate` output string
- **API reference**: rewrites to match actual routes (by pipeline name, not UUID); adds all missing endpoints (`/disable`, `/enable`, `/latest-run`, `/run-history`, `/artifacts`, `/pipeline-runs`, `/version`, `/ready`, `/examples/...`); fixes the `specs/apply` request body shape (`yaml` + `created_by`)
- **YAML spec**: replaces the old `connection: "host:port/db"` + `credentials:` format with the actual flat-map (`host`/`port`/`database`/`username`/`passwordRef`); adds destination connection fields (`schema`, `tablePrefix`, `applicationName`, `sslMode`); adds `schemaEvolution` runtime block; adds `upsert`/`replace` write modes; syncs all three examples with the actual files in `examples/`
- **Connectors**: removes fictional `SourceConnector`/`DestinationConnector` trait definitions; documents real types (`PostgresSource`, `PostgresDestinationLoader`); fixes PK discovery mechanism, raw table schema, `_applied_chunks` schema, and 20-digit sequence padding
- **Crate guide**: corrects `PipelineStatus` values, `StageChunkStore` trait name, connector type names, and `astra-secrets` stub description
- **Staging contract**: fixes checkpoint ledger to single per-pipeline JSON file (not per-stream `.ledger` files); fixes `_applied_chunks` schema; fixes `StageChunkStore` trait name
- **Quickstart**: restructured into two parallel tracks — CLI path and Web UI path — with a full YAML Studio onboarding walkthrough (register pipeline, trigger run, inspect run history and table drill-down)

## Test plan

- [ ] Spot-check YAML examples in the docs parse correctly: `cargo run -p astra -- validate examples/smoke-local-snapshot.astra.yaml`
- [ ] Verify the API endpoint list against `apps/control-plane/src/http/mod.rs`
- [ ] Build the Docusaurus site: `cd website && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)