### PR TITLE
refactor: extract schema migrations into versioned SQL files via refinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "refinery",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2025,6 +2026,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "refinery"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba5d693abf62492c37268512ff35b77655d2e957ca53dab85bf993fe9172d15"
+dependencies = [
+ "refinery-core",
+ "refinery-macros",
+]
+
+[[package]]
+name = "refinery-core"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a83581f18c1a4c3a6ebd7a174bdc665f17f618d79f7edccb6a0ac67e660b319"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "log",
+ "regex",
+ "serde",
+ "siphasher",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-postgres",
+ "toml",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "refinery-macros"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c225407d8e52ef8cf094393781ecda9a99d6544ec28d90a6915751de259264"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "refinery-core",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2439,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2886,6 +2941,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3595,6 +3691,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 async-trait = "0.1"
 sha2 = "0.10"
 tokio-postgres = { version = "0.7", default-features = false, features = ["runtime", "with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
+refinery = { version = "0.8", features = ["tokio-postgres"] }
 tower-http = { version = "0.5", features = ["fs", "trace"] }
 astra-api = { path = "../../crates/astra-api" }
 astra-core = { path = "../../crates/astra-core" }

--- a/apps/control-plane/migrations/V1__initial_schema.sql
+++ b/apps/control-plane/migrations/V1__initial_schema.sql
@@ -1,0 +1,83 @@
+CREATE TABLE IF NOT EXISTS pipelines (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    source_kind TEXT NOT NULL,
+    destination_kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    active_spec_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_specs (
+    id UUID PRIMARY KEY,
+    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    spec_version TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    spec_yaml TEXT NOT NULL,
+    spec_json JSONB NOT NULL,
+    created_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (pipeline_id, version),
+    UNIQUE (pipeline_id, content_hash)
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id UUID PRIMARY KEY,
+    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+    trigger_mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    worker_id TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ,
+    stats_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pipeline_started_at
+    ON pipeline_runs (pipeline_id, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS staged_artifacts (
+    id UUID PRIMARY KEY,
+    pipeline_run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    stream_name TEXT NOT NULL,
+    partition_key TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    bucket TEXT NOT NULL,
+    object_key TEXT NOT NULL,
+    bytes_written BIGINT NOT NULL,
+    row_count BIGINT NOT NULL,
+    content_type TEXT NOT NULL,
+    content_encoding TEXT NOT NULL,
+    schema_fingerprint TEXT,
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (pipeline_run_id, object_key),
+    UNIQUE (pipeline_run_id, stream_name, partition_key, sequence)
+);
+
+CREATE INDEX IF NOT EXISTS idx_staged_artifacts_run_stream_sequence
+    ON staged_artifacts (pipeline_run_id, stream_name, partition_key, sequence);
+
+CREATE TABLE IF NOT EXISTS table_executions (
+    id UUID PRIMARY KEY,
+    pipeline_run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
+    stream_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    rows_processed BIGINT NOT NULL DEFAULT 0,
+    rows_total BIGINT,
+    error_summary TEXT,
+    checkpoint_next_sequence BIGINT,
+    checkpoint_rows_staged BIGINT,
+    checkpoint_last_chunk_key TEXT,
+    checkpoint_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(pipeline_run_id, stream_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_table_executions_run
+    ON table_executions (pipeline_run_id);

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -16,6 +16,8 @@ use tokio::sync::Mutex;
 use tokio_postgres::{types::Json, Client, NoTls, Row};
 use uuid::Uuid;
 
+refinery::embed_migrations!("migrations");
+
 #[derive(Clone)]
 pub struct PostgresPipelineRepository {
     client: Arc<Mutex<Client>>,
@@ -23,7 +25,7 @@ pub struct PostgresPipelineRepository {
 
 impl PostgresPipelineRepository {
     pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
-        let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        let (mut client, connection) = tokio_postgres::connect(database_url, NoTls)
             .await
             .with_context(|| {
                 format!("failed to connect to Postgres using ASTRA_DATABASE_URL: {database_url}")
@@ -35,113 +37,14 @@ impl PostgresPipelineRepository {
             }
         });
 
-        let repository = Self {
+        migrations::runner()
+            .run_async(&mut client)
+            .await
+            .context("failed to run schema migrations")?;
+
+        Ok(Self {
             client: Arc::new(Mutex::new(client)),
-        };
-        repository.ensure_schema().await?;
-        Ok(repository)
-    }
-
-    async fn ensure_schema(&self) -> anyhow::Result<()> {
-        self.client
-            .lock()
-            .await
-            .batch_execute(
-                r#"
-                CREATE TABLE IF NOT EXISTS pipelines (
-                    id UUID PRIMARY KEY,
-                    name TEXT NOT NULL UNIQUE,
-                    source_kind TEXT NOT NULL,
-                    destination_kind TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    active_spec_id UUID,
-                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                );
-
-                CREATE TABLE IF NOT EXISTS pipeline_specs (
-                    id UUID PRIMARY KEY,
-                    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
-                    version INTEGER NOT NULL,
-                    spec_version TEXT NOT NULL,
-                    content_hash TEXT NOT NULL,
-                    spec_yaml TEXT NOT NULL,
-                    spec_json JSONB NOT NULL,
-                    created_by TEXT,
-                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    UNIQUE (pipeline_id, version),
-                    UNIQUE (pipeline_id, content_hash)
-                );
-
-                CREATE TABLE IF NOT EXISTS pipeline_runs (
-                    id UUID PRIMARY KEY,
-                    pipeline_id UUID NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
-                    trigger_mode TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    worker_id TEXT,
-                    started_at TIMESTAMPTZ NOT NULL,
-                    finished_at TIMESTAMPTZ,
-                    stats_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pipeline_started_at
-                    ON pipeline_runs (pipeline_id, started_at DESC);
-
-                CREATE TABLE IF NOT EXISTS staged_artifacts (
-                    id UUID PRIMARY KEY,
-                    pipeline_run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
-                    stream_name TEXT NOT NULL,
-                    partition_key TEXT NOT NULL,
-                    sequence BIGINT NOT NULL,
-                    bucket TEXT NOT NULL,
-                    object_key TEXT NOT NULL,
-                    bytes_written BIGINT NOT NULL,
-                    row_count BIGINT NOT NULL,
-                    content_type TEXT NOT NULL,
-                    content_encoding TEXT NOT NULL,
-                    schema_fingerprint TEXT,
-                    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    UNIQUE (pipeline_run_id, object_key),
-                    UNIQUE (pipeline_run_id, stream_name, partition_key, sequence)
-                );
-
-                CREATE INDEX IF NOT EXISTS idx_staged_artifacts_run_stream_sequence
-                    ON staged_artifacts (pipeline_run_id, stream_name, partition_key, sequence);
-
-                CREATE TABLE IF NOT EXISTS table_executions (
-                    id UUID PRIMARY KEY,
-                    pipeline_run_id UUID NOT NULL REFERENCES pipeline_runs(id) ON DELETE CASCADE,
-                    stream_name TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    rows_processed BIGINT NOT NULL DEFAULT 0,
-                    rows_total BIGINT,
-                    error_summary TEXT,
-                    checkpoint_next_sequence BIGINT,
-                    checkpoint_rows_staged BIGINT,
-                    checkpoint_last_chunk_key TEXT,
-                    checkpoint_completed BOOLEAN NOT NULL DEFAULT FALSE,
-                    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    finished_at TIMESTAMPTZ,
-                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    UNIQUE(pipeline_run_id, stream_name)
-                );
-
-                ALTER TABLE table_executions
-                    ADD COLUMN IF NOT EXISTS checkpoint_next_sequence BIGINT,
-                    ADD COLUMN IF NOT EXISTS checkpoint_rows_staged BIGINT,
-                    ADD COLUMN IF NOT EXISTS checkpoint_last_chunk_key TEXT,
-                    ADD COLUMN IF NOT EXISTS checkpoint_completed BOOLEAN NOT NULL DEFAULT FALSE;
-
-                CREATE INDEX IF NOT EXISTS idx_table_executions_run
-                    ON table_executions (pipeline_run_id);
-                "#,
-            )
-            .await
-            .context("failed to bootstrap pipeline persistence schema")?;
-        Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
Closes #126

## Summary
- Added `refinery = { version = "0.8", features = ["tokio-postgres"] }` dependency
- Created `apps/control-plane/migrations/V1__initial_schema.sql` with all DDL extracted from `ensure_schema()`
- Removed ~100 lines of inline SQL from `ensure_schema()` — schema changes are now reviewable standalone SQL diffs
- Refinery runs migrations at startup via `migrations::runner().run_async()`, tracking applied versions in a `refinery_schema_history` table

## Test plan
- [ ] `cargo build -p astra-control-plane` passes
- [ ] `cargo clippy -p astra-control-plane` passes with zero warnings
- [ ] Start control plane against a fresh Postgres — schema is created correctly
- [ ] Restart control plane — migrations are not re-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)