### PR TITLE
fix: use typed NotFoundError in InMemoryPipelineRepository (#127)

### DIFF
--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -6,7 +6,6 @@ use crate::{
         UpsertTableExecutionRecord,
     },
 };
-use anyhow::anyhow;
 use astra_metadata::PipelineStatus;
 use async_trait::async_trait;
 use chrono::Utc;
@@ -70,7 +69,7 @@ impl PipelineRepository for InMemoryPipelineRepository {
             run.updated_at = Utc::now();
             Ok(run.clone())
         } else {
-            Err(anyhow!("pipeline run {} not found", run_id))
+            Err(anyhow::Error::new(NotFoundError(run_id.to_string())))
         }
     }
 
@@ -130,7 +129,7 @@ impl PipelineRepository for InMemoryPipelineRepository {
     ) -> anyhow::Result<PipelineRunRecord> {
         let pipelines = self.inner.read().await;
         if !pipelines.contains_key(&run.pipeline_name) {
-            return Err(anyhow!("pipeline '{}' does not exist", run.pipeline_name));
+            return Err(anyhow::Error::new(NotFoundError(run.pipeline_name.clone())));
         }
         drop(pipelines);
 
@@ -214,10 +213,9 @@ impl PipelineRepository for InMemoryPipelineRepository {
     ) -> anyhow::Result<StagedArtifactRecord> {
         let runs = self.runs.read().await;
         if !runs.contains_key(&artifact.pipeline_run_id) {
-            return Err(anyhow!(
-                "pipeline run '{}' does not exist",
-                artifact.pipeline_run_id
-            ));
+            return Err(anyhow::Error::new(NotFoundError(
+                artifact.pipeline_run_id.to_string(),
+            )));
         }
         drop(runs);
 
@@ -287,10 +285,9 @@ impl PipelineRepository for InMemoryPipelineRepository {
     ) -> anyhow::Result<TableExecutionRecord> {
         let runs = self.runs.read().await;
         if !runs.contains_key(&record.pipeline_run_id) {
-            return Err(anyhow!(
-                "pipeline run '{}' does not exist",
-                record.pipeline_run_id
-            ));
+            return Err(anyhow::Error::new(NotFoundError(
+                record.pipeline_run_id.to_string(),
+            )));
         }
         drop(runs);
 


### PR DESCRIPTION
## Summary

- Replace all `anyhow!("... not found")` string-based errors in `InMemoryPipelineRepository` with `anyhow::Error::new(NotFoundError(...))`, matching the pattern already used in `PostgresPipelineRepository`
- Remove the now-unused `use anyhow::anyhow;` import
- Affected error sites: `update_pipeline_run_status`, `create_pipeline_run`, `record_staged_artifact`, and `upsert_table_execution`

The two repository implementations are meant to be interchangeable behind the `PipelineRepository` trait. The `AppError::from<anyhow::Error>` conversion in `error.rs` downcasts to `NotFoundError` to produce a proper 404 HTTP response — this only works if the error is actually a `NotFoundError` value, not a plain string error. With the old string-based errors, not-found conditions in the in-memory backend would incorrectly surface as 500 Internal Server Errors instead of 404s.

Closes #127

## Test plan

- [x] `cargo clippy -p astra-control-plane` — no warnings or errors
- [x] `cargo fmt --all` — passes pre-commit hook
- [x] Both `delete_pipeline` and `update_pipeline_status` already used `NotFoundError`; the remaining four error sites are now consistent
- [ ] Manual smoke: start control plane in in-memory mode, attempt to GET/POST a non-existent pipeline, verify 404 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)