### PR TITLE
refactor: introduce ApplySpecRecord — decouple repository from AstraSpec (#123)

### DIFF
--- a/apps/control-plane/src/repositories/memory/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/memory/pipeline_repository.rs
@@ -1,9 +1,9 @@
 use crate::{
     error::NotFoundError,
     repositories::{
-        AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
-        PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord, TableExecutionRecord,
-        UpsertTableExecutionRecord,
+        AppliedPipelineRecord, ApplySpecRecord, CreatePipelineRunRecord, PipelineRecord,
+        PipelineRepository, PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+        TableExecutionRecord, UpsertTableExecutionRecord,
     },
 };
 use anyhow::anyhow;
@@ -81,15 +81,10 @@ impl PipelineRepository for InMemoryPipelineRepository {
         Ok(items)
     }
 
-    async fn apply_spec(
-        &self,
-        spec: astra_yaml::AstraSpec,
-        raw_yaml: String,
-        created_by: Option<String>,
-    ) -> anyhow::Result<AppliedPipelineRecord> {
+    async fn apply_spec(&self, record: ApplySpecRecord) -> anyhow::Result<AppliedPipelineRecord> {
         let mut guard = self.inner.write().await;
-        let name = spec.pipeline.name.clone();
-        let content_hash = hash_content(&raw_yaml);
+        let name = record.name.clone();
+        let content_hash = hash_content(&record.raw_yaml);
 
         let next_version = match guard.get(&name) {
             Some(existing) if existing.latest_hash == content_hash => existing.record.spec_version,
@@ -97,29 +92,29 @@ impl PipelineRepository for InMemoryPipelineRepository {
             None => 1,
         };
 
-        let record = PipelineRecord {
+        let pipeline_record = PipelineRecord {
             name: name.clone(),
-            source_kind: spec.source.kind.clone(),
-            destination_kind: spec.destination.kind.clone(),
+            source_kind: record.source_kind.clone(),
+            destination_kind: record.destination_kind.clone(),
             status: PipelineStatus::Active,
             spec_version: next_version,
         };
 
         let stored = StoredPipeline {
-            record: record.clone(),
+            record: pipeline_record.clone(),
             latest_hash: content_hash.clone(),
             pipeline_id: Uuid::new_v4(),
             source_id: Uuid::new_v4(),
             destination_id: Uuid::new_v4(),
             active_spec_id: Uuid::new_v4(),
-            raw_yaml,
-            created_by,
+            raw_yaml: record.raw_yaml,
+            created_by: record.created_by,
             updated_at: Utc::now(),
         };
         guard.insert(name, stored);
 
         Ok(AppliedPipelineRecord {
-            pipeline: record,
+            pipeline: pipeline_record,
             content_hash,
         })
     }

--- a/apps/control-plane/src/repositories/mod.rs
+++ b/apps/control-plane/src/repositories/mod.rs
@@ -4,8 +4,8 @@ pub mod postgres;
 
 pub use memory::InMemoryPipelineRepository;
 pub use pipeline_repository::{
-    AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
-    PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord, TableExecutionRecord,
-    UpsertTableExecutionRecord,
+    AppliedPipelineRecord, ApplySpecRecord, CreatePipelineRunRecord, PipelineRecord,
+    PipelineRepository, PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+    TableExecutionRecord, UpsertTableExecutionRecord,
 };
 pub use postgres::PostgresPipelineRepository;

--- a/apps/control-plane/src/repositories/pipeline_repository.rs
+++ b/apps/control-plane/src/repositories/pipeline_repository.rs
@@ -5,6 +5,18 @@ use serde_json::Value;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
+pub struct ApplySpecRecord {
+    pub name: String,
+    pub source_kind: String,
+    pub destination_kind: String,
+    pub mode: String,
+    pub spec_version: String,
+    pub spec_json: serde_json::Value,
+    pub raw_yaml: String,
+    pub created_by: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct PipelineRecord {
     pub name: String,
     pub source_kind: String,
@@ -118,12 +130,7 @@ pub trait PipelineRepository: Send + Sync {
         stats_json: serde_json::Value,
     ) -> anyhow::Result<PipelineRunRecord>;
     async fn list_pipelines(&self) -> anyhow::Result<Vec<PipelineRecord>>;
-    async fn apply_spec(
-        &self,
-        spec: astra_yaml::AstraSpec,
-        raw_yaml: String,
-        created_by: Option<String>,
-    ) -> anyhow::Result<AppliedPipelineRecord>;
+    async fn apply_spec(&self, record: ApplySpecRecord) -> anyhow::Result<AppliedPipelineRecord>;
     async fn create_pipeline_run(
         &self,
         run: CreatePipelineRunRecord,

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -1,9 +1,9 @@
 use crate::{
     error::NotFoundError,
     repositories::{
-        AppliedPipelineRecord, CreatePipelineRunRecord, PipelineRecord, PipelineRepository,
-        PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord, TableExecutionRecord,
-        UpsertTableExecutionRecord,
+        AppliedPipelineRecord, ApplySpecRecord, CreatePipelineRunRecord, PipelineRecord,
+        PipelineRepository, PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
+        TableExecutionRecord, UpsertTableExecutionRecord,
     },
 };
 use anyhow::{anyhow, Context};
@@ -126,19 +126,15 @@ impl PipelineRepository for PostgresPipelineRepository {
             .collect::<anyhow::Result<Vec<_>>>()?)
     }
 
-    async fn apply_spec(
-        &self,
-        spec: astra_yaml::AstraSpec,
-        raw_yaml: String,
-        created_by: Option<String>,
-    ) -> anyhow::Result<AppliedPipelineRecord> {
-        let pipeline_name = spec.pipeline.name.clone();
-        let source_kind = spec.source.kind.clone();
-        let destination_kind = spec.destination.kind.clone();
+    async fn apply_spec(&self, record: ApplySpecRecord) -> anyhow::Result<AppliedPipelineRecord> {
+        let pipeline_name = record.name.clone();
+        let source_kind = record.source_kind.clone();
+        let destination_kind = record.destination_kind.clone();
         let status = PipelineStatus::Active;
-        let spec_version_label = spec.version.clone();
-        let spec_model: Value =
-            serde_json::to_value(&spec).context("failed to serialize normalized spec JSON")?;
+        let spec_version_label = record.spec_version.clone();
+        let spec_model: Value = record.spec_json.clone();
+        let raw_yaml = record.raw_yaml.clone();
+        let created_by = record.created_by.clone();
         let content_hash = hash_content(&raw_yaml);
 
         let mut client = self

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -4,7 +4,7 @@ use crate::{
         StagedArtifactResponse, TableExecutionResponse, UpsertTableExecutionRequest,
     },
     repositories::{
-        CreatePipelineRunRecord, PipelineRepository, RecordStagedArtifactRecord,
+        ApplySpecRecord, CreatePipelineRunRecord, PipelineRepository, RecordStagedArtifactRecord,
         UpsertTableExecutionRecord,
     },
 };
@@ -39,7 +39,22 @@ impl PipelineService {
                 "spec apply does not execute CDC yet. Astra's Postgres source is currently limited to schema discovery and snapshot staging; remove pipeline.mode=cdc and source.capture.cdc before applying this spec."
             );
         }
-        let applied = self.repository.apply_spec(spec, yaml, created_by).await?;
+        let spec_json = serde_json::to_value(&spec)
+            .map_err(|e| anyhow::anyhow!("failed to serialize spec to JSON: {}", e))?;
+        let record = ApplySpecRecord {
+            name: spec.pipeline.name.clone(),
+            source_kind: spec.source.kind.clone(),
+            destination_kind: spec.destination.kind.clone(),
+            mode: serde_json::to_value(&spec.pipeline.mode)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_owned))
+                .unwrap_or_else(|| format!("{:?}", spec.pipeline.mode).to_lowercase()),
+            spec_version: spec.version.clone(),
+            spec_json,
+            raw_yaml: yaml,
+            created_by,
+        };
+        let applied = self.repository.apply_spec(record).await?;
         Ok(ApplySpecResponse {
             pipeline_name: applied.pipeline.name,
             spec_version: applied.pipeline.spec_version,

--- a/apps/control-plane/tests/pg-persistence.rs
+++ b/apps/control-plane/tests/pg-persistence.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use astra_control_plane::repositories::{
-    pipeline_repository::UpsertTableExecutionRecord, CreatePipelineRunRecord, PipelineRecord,
-    PipelineRepository, PipelineRunRecord, PostgresPipelineRepository, RecordStagedArtifactRecord,
-    StagedArtifactRecord,
+    pipeline_repository::UpsertTableExecutionRecord, ApplySpecRecord, CreatePipelineRunRecord,
+    PipelineRecord, PipelineRepository, PipelineRunRecord, PostgresPipelineRepository,
+    RecordStagedArtifactRecord, StagedArtifactRecord,
 };
 use astra_metadata::PipelineStatus;
 use astra_yaml::AstraSpec;
@@ -72,9 +72,20 @@ runtime:
     let raw_yaml = spec_yaml.to_string();
 
     // apply_spec
-    let applied = repo1
-        .apply_spec(spec.clone(), raw_yaml.clone(), None)
-        .await?;
+    let apply_record = ApplySpecRecord {
+        name: spec.pipeline.name.clone(),
+        source_kind: spec.source.kind.clone(),
+        destination_kind: spec.destination.kind.clone(),
+        mode: serde_json::to_value(&spec.pipeline.mode)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_owned))
+            .unwrap_or_default(),
+        spec_version: spec.version.clone(),
+        spec_json: serde_json::to_value(&spec).context("serialize spec")?,
+        raw_yaml: raw_yaml.clone(),
+        created_by: None,
+    };
+    let applied = repo1.apply_spec(apply_record).await?;
     assert_eq!(applied.pipeline.name, pipeline_name);
     assert_eq!(applied.pipeline.status, PipelineStatus::Active);
 
@@ -306,7 +317,20 @@ runtime:
     let spec: AstraSpec = serde_yaml::from_str(spec_yaml)?;
     let raw_yaml = spec_yaml.to_string();
 
-    repo.apply_spec(spec, raw_yaml, None).await?;
+    let apply_record = ApplySpecRecord {
+        name: spec.pipeline.name.clone(),
+        source_kind: spec.source.kind.clone(),
+        destination_kind: spec.destination.kind.clone(),
+        mode: serde_json::to_value(&spec.pipeline.mode)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_owned))
+            .unwrap_or_default(),
+        spec_version: spec.version.clone(),
+        spec_json: serde_json::to_value(&spec)?,
+        raw_yaml: raw_yaml.clone(),
+        created_by: None,
+    };
+    repo.apply_spec(apply_record).await?;
 
     let pipelines: Vec<PipelineRecord> = repo.list_pipelines().await?;
     assert!(pipelines.iter().any(|p| p.name == pipeline_name));


### PR DESCRIPTION
## Summary

- Introduces a new `ApplySpecRecord` plain-data struct in `pipeline_repository.rs` containing all fields the repository needs: `name`, `source_kind`, `destination_kind`, `mode`, `spec_version`, `spec_json`, `raw_yaml`, and `created_by`.
- Changes `PipelineRepository::apply_spec` trait method to accept `ApplySpecRecord` instead of `AstraSpec + raw_yaml + created_by`.
- Updates both `PostgresPipelineRepository` and `InMemoryPipelineRepository` implementations to read from `ApplySpecRecord` fields, removing their direct dependency on `astra_yaml`.
- Updates `PipelineService::apply_spec` to parse/validate the YAML spec as before, then decompose the `AstraSpec` into an `ApplySpecRecord` before passing it to the repo.
- Updates integration test `pg-persistence.rs` to build `ApplySpecRecord` from the parsed spec rather than calling the old signature.

This enforces the architectural rule that storage abstractions should never depend on domain objects — the service layer owns the translation.

Closes #123

## Test plan

- [x] `cargo build -p astra-control-plane` compiles cleanly
- [x] `cargo fmt --all` passes (enforced by pre-commit hook)
- [ ] Run `cargo test -p astra-control-plane` against a live Postgres to confirm integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)