### PR TITLE
refactor: centralise input validation in service layer (#122)

### DIFF
--- a/apps/control-plane/src/error.rs
+++ b/apps/control-plane/src/error.rs
@@ -10,6 +10,10 @@ use serde::Serialize;
 pub struct NotFoundError(pub String);
 
 #[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct BadRequestError(pub String);
+
+#[derive(Debug, thiserror::Error)]
 pub enum AppError {
     #[error(transparent)]
     NotFound(#[from] NotFoundError),
@@ -46,6 +50,10 @@ impl From<anyhow::Error> for AppError {
 
         if let Some(not_found) = value.downcast_ref::<NotFoundError>() {
             return Self::NotFound(NotFoundError(not_found.0.clone()));
+        }
+
+        if let Some(bad_request) = value.downcast_ref::<BadRequestError>() {
+            return Self::BadRequest(bad_request.0.clone());
         }
 
         Self::Internal(value.to_string())

--- a/apps/control-plane/src/http/pipelines.rs
+++ b/apps/control-plane/src/http/pipelines.rs
@@ -28,9 +28,6 @@ pub async fn apply_spec(
     State(state): State<AppState>,
     Json(request): Json<ApplySpecRequest>,
 ) -> Result<Json<crate::models::api::ApplySpecResponse>, AppError> {
-    if request.yaml.trim().is_empty() {
-        return Err(AppError::BadRequest("yaml must not be empty".to_string()));
-    }
     let response = state
         .pipeline_service
         .apply_spec(request.yaml, request.created_by)
@@ -42,17 +39,6 @@ pub async fn create_pipeline_run(
     State(state): State<AppState>,
     Json(request): Json<CreatePipelineRunRequest>,
 ) -> Result<Json<crate::models::api::PipelineRunResponse>, AppError> {
-    if request.pipeline_name.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "pipeline_name must not be empty".to_string(),
-        ));
-    }
-    if request.trigger_mode.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "trigger_mode must not be empty".to_string(),
-        ));
-    }
-
     let response = state
         .pipeline_service
         .create_pipeline_run(
@@ -116,17 +102,6 @@ pub async fn record_staged_artifact(
     Path(pipeline_run_id): Path<Uuid>,
     Json(request): Json<RecordStagedArtifactRequest>,
 ) -> Result<Json<crate::models::api::StagedArtifactResponse>, AppError> {
-    if request.stream_name.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "stream_name must not be empty".to_string(),
-        ));
-    }
-    if request.object_key.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "object_key must not be empty".to_string(),
-        ));
-    }
-
     let response = state
         .pipeline_service
         .record_staged_artifact(RecordStagedArtifactRecord {
@@ -194,12 +169,6 @@ pub async fn upsert_table_execution(
     Path(pipeline_run_id): Path<Uuid>,
     Json(request): Json<UpsertTableExecutionRequest>,
 ) -> Result<Json<TableExecutionResponse>, AppError> {
-    if request.stream_name.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "stream_name must not be empty".to_string(),
-        ));
-    }
-
     let response = state
         .pipeline_service
         .upsert_table_execution(pipeline_run_id, request)

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::BadRequestError,
     models::api::{
         ApplySpecResponse, PipelineRunResponse, PipelineSummaryResponse, Progress,
         StagedArtifactResponse, TableExecutionResponse, UpsertTableExecutionRequest,
@@ -32,6 +33,9 @@ impl PipelineService {
         yaml: String,
         created_by: Option<String>,
     ) -> anyhow::Result<ApplySpecResponse> {
+        if yaml.trim().is_empty() {
+            anyhow::bail!(BadRequestError("yaml must not be empty".to_string()));
+        }
         let spec = astra_yaml::AstraSpec::parse_yaml(&yaml)?;
         spec.validate()?;
         if spec.requests_cdc() {
@@ -56,6 +60,16 @@ impl PipelineService {
         worker_id: Option<String>,
         started_at: Option<chrono::DateTime<Utc>>,
     ) -> anyhow::Result<PipelineRunResponse> {
+        if pipeline_name.trim().is_empty() {
+            anyhow::bail!(BadRequestError(
+                "pipeline_name must not be empty".to_string()
+            ));
+        }
+        if trigger_mode.trim().is_empty() {
+            anyhow::bail!(BadRequestError(
+                "trigger_mode must not be empty".to_string()
+            ));
+        }
         let run = self
             .repository
             .create_pipeline_run(CreatePipelineRunRecord {
@@ -101,6 +115,12 @@ impl PipelineService {
         &self,
         mut record: RecordStagedArtifactRecord,
     ) -> anyhow::Result<StagedArtifactResponse> {
+        if record.stream_name.trim().is_empty() {
+            anyhow::bail!(BadRequestError("stream_name must not be empty".to_string()));
+        }
+        if record.object_key.trim().is_empty() {
+            anyhow::bail!(BadRequestError("object_key must not be empty".to_string()));
+        }
         if record.metadata_json.is_null() {
             record.metadata_json = serde_json::json!({});
         }
@@ -135,6 +155,9 @@ impl PipelineService {
         pipeline_run_id: Uuid,
         request: UpsertTableExecutionRequest,
     ) -> anyhow::Result<TableExecutionResponse> {
+        if request.stream_name.trim().is_empty() {
+            anyhow::bail!(BadRequestError("stream_name must not be empty".to_string()));
+        }
         let record = UpsertTableExecutionRecord {
             pipeline_run_id,
             stream_name: request.stream_name,


### PR DESCRIPTION
## Summary

- Moves all HTTP-layer input validation guards into `PipelineService`, ensuring validation runs for every caller (HTTP, CLI, future callers) rather than only via the HTTP path.
- Introduces `BadRequestError` newtype in `error.rs` (mirrors the existing `NotFoundError` pattern), and adds a downcast arm in `From<anyhow::Error> for AppError` so service-level `anyhow::bail!(BadRequestError(...))` correctly maps to `AppError::BadRequest` (HTTP 400).
- HTTP handlers now pass data straight through to the service with no pre-checking.

## What moved where

| Guard removed from HTTP handler | Added to service method |
|---|---|
| `apply_spec` — `yaml.trim().is_empty()` | `PipelineService::apply_spec` |
| `create_pipeline_run` — `pipeline_name.trim().is_empty()` | `PipelineService::create_pipeline_run` |
| `create_pipeline_run` — `trigger_mode.trim().is_empty()` | `PipelineService::create_pipeline_run` |
| `record_staged_artifact` — `stream_name.trim().is_empty()` | `PipelineService::record_staged_artifact` |
| `record_staged_artifact` — `object_key.trim().is_empty()` | `PipelineService::record_staged_artifact` |
| `upsert_table_execution` — `stream_name.trim().is_empty()` | `PipelineService::upsert_table_execution` |

The valid-status-string check already in `pipeline_service.rs` was left untouched — it was already in the correct place.

## Test plan

- [x] `cargo build -p astra-control-plane` passes cleanly
- [x] `cargo fmt --all` applied (enforced by pre-commit hook)
- [ ] Manually POST an empty `yaml` to `/api/v1/specs/apply` and confirm HTTP 400 is returned
- [ ] Manually POST an empty `pipeline_name` to `/api/v1/pipeline-runs` and confirm HTTP 400

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)