### PR TITLE
feat: introduce AstraError with retryable/permanent classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- `AstraError` enum in `astra-metadata` — structured error type with retryable/permanent classification and machine-readable `code()` field (`CONNECTION_FAILED`, `QUERY_FAILED`, `STAGING_FAILED`, `VALIDATION_ERROR`, `NOT_FOUND`, `INTERNAL_ERROR`).
+- `AppError::Astra` variant in the control plane — `AstraError` values propagate directly to HTTP responses with correct status codes (404, 400, 502, 500).
+- HTTP error responses now include `{ "error": "...", "code": "...", "retryable": bool }` instead of just `{ "error": "..." }`.
+- Postgres connector `connect()` maps connection failures to `AstraError::ConnectionFailed { retryable: true }`.
+- Postgres `discover_tables()` maps column/PK query failures to `AstraError::QueryFailed { retryable: false }` and missing tables to `AstraError::NotFound`.
+
+---
+
 ## [0.1.0] - 2026-04-01
 
 First public release of Astra. One complete vertical slice: Postgres snapshot → local/MinIO staging → Postgres raw destination, with a control plane API and web UI for visibility.

--- a/apps/control-plane/src/error.rs
+++ b/apps/control-plane/src/error.rs
@@ -1,3 +1,4 @@
+use astra_metadata::AstraError;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -23,22 +24,76 @@ pub enum AppError {
     BadRequest(String),
     #[error("internal error: {0}")]
     Internal(String),
+    /// Typed Astra error surfaced from the service or connector layer.
+    #[error(transparent)]
+    Astra(#[from] AstraError),
 }
 
 #[derive(Serialize)]
 struct ErrorBody {
     error: String,
+    code: String,
+    retryable: bool,
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
-            Self::NotFound(e) => (StatusCode::NOT_FOUND, e.to_string()),
-            Self::Validation(e) => (StatusCode::BAD_REQUEST, e.to_string()),
-            Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            Self::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+        let (status, body) = match self {
+            Self::NotFound(e) => (
+                StatusCode::NOT_FOUND,
+                ErrorBody {
+                    error: e.to_string(),
+                    code: "NOT_FOUND".to_string(),
+                    retryable: false,
+                },
+            ),
+            Self::Validation(e) => (
+                StatusCode::BAD_REQUEST,
+                ErrorBody {
+                    error: e.to_string(),
+                    code: "VALIDATION_ERROR".to_string(),
+                    retryable: false,
+                },
+            ),
+            Self::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                ErrorBody {
+                    error: msg,
+                    code: "BAD_REQUEST".to_string(),
+                    retryable: false,
+                },
+            ),
+            Self::Internal(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorBody {
+                    error: msg,
+                    code: "INTERNAL_ERROR".to_string(),
+                    retryable: false,
+                },
+            ),
+            Self::Astra(astra_err) => {
+                let status = match &astra_err {
+                    AstraError::NotFound(_) => StatusCode::NOT_FOUND,
+                    AstraError::ValidationError(_) => StatusCode::BAD_REQUEST,
+                    AstraError::ConnectionFailed { .. }
+                    | AstraError::QueryFailed { .. }
+                    | AstraError::StagingFailed { .. } => StatusCode::BAD_GATEWAY,
+                    AstraError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                };
+                let retryable = astra_err.is_retryable();
+                let code = astra_err.code().to_string();
+                let error = astra_err.to_string();
+                (
+                    status,
+                    ErrorBody {
+                        error,
+                        code,
+                        retryable,
+                    },
+                )
+            }
         };
-        (status, Json(ErrorBody { error: message })).into_response()
+        (status, Json(body)).into_response()
     }
 }
 

--- a/crates/astra-connectors/Cargo.toml
+++ b/crates/astra-connectors/Cargo.toml
@@ -18,4 +18,5 @@ tokio.workspace = true
 flate2 = "1"
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 astra-yaml = { path = "../astra-yaml" }
+astra-metadata = { path = "../astra-metadata" }
 astra-runtime = { path = "../astra-runtime" }

--- a/crates/astra-connectors/src/postgres.rs
+++ b/crates/astra-connectors/src/postgres.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Context};
+use astra_metadata::AstraError;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tokio_postgres::{types::Type, Client, NoTls};
@@ -465,10 +466,15 @@ async fn connect(config: &PostgresConnectionConfig) -> anyhow::Result<Client> {
         pg_config.password(password);
     }
 
-    let (client, connection) = pg_config
-        .connect(NoTls)
-        .await
-        .context("failed to connect to Postgres source")?;
+    let (client, connection) = pg_config.connect(NoTls).await.map_err(|e| {
+        AstraError::connection_failed_retryable(
+            format!(
+                "failed to connect to Postgres source at {}:{}",
+                config.host, config.port
+            ),
+            e,
+        )
+    })?;
 
     tokio::spawn(async move {
         if let Err(error) = connection.await {
@@ -510,10 +516,18 @@ async fn discover_tables(
                 &[&schema, &table],
             )
             .await
-            .with_context(|| format!("failed to inspect columns for {table_name}"))?;
+            .map_err(|e| {
+                AstraError::query_failed_permanent(
+                    format!("failed to inspect columns for {table_name}"),
+                    e,
+                )
+            })?;
 
         if columns.is_empty() {
-            bail!("table {table_name} was not found in Postgres");
+            return Err(AstraError::NotFound(format!(
+                "table {table_name} was not found in Postgres"
+            ))
+            .into());
         }
 
         let primary_key_rows = client
@@ -530,7 +544,12 @@ async fn discover_tables(
                 &[&schema, &table],
             )
             .await
-            .with_context(|| format!("failed to inspect primary key for {table_name}"))?;
+            .map_err(|e| {
+                AstraError::query_failed_permanent(
+                    format!("failed to inspect primary key for {table_name}"),
+                    e,
+                )
+            })?;
 
         tables.push(SourceTable {
             schema: schema.to_string(),

--- a/crates/astra-metadata/Cargo.toml
+++ b/crates/astra-metadata/Cargo.toml
@@ -13,4 +13,5 @@ anyhow.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 uuid.workspace = true

--- a/crates/astra-metadata/src/error.rs
+++ b/crates/astra-metadata/src/error.rs
@@ -1,0 +1,122 @@
+use thiserror::Error;
+
+/// Top-level structured error type for Astra operations.
+///
+/// Carries enough information for callers to decide whether to retry and for
+/// the control plane to return a machine-readable error response.
+#[derive(Debug, Error)]
+pub enum AstraError {
+    /// A connection to an external system (database, object store) could not
+    /// be established. Typically retryable — the host may be temporarily
+    /// unavailable.
+    #[error("connection failed: {message}")]
+    ConnectionFailed {
+        message: String,
+        retryable: bool,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+
+    /// A query or read operation against an external system failed. SQL syntax
+    /// errors and missing tables are permanent; lock timeouts are retryable.
+    #[error("query failed: {message}")]
+    QueryFailed {
+        message: String,
+        retryable: bool,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+
+    /// Writing or reading from the staging layer failed.
+    #[error("staging failed: {message}")]
+    StagingFailed {
+        message: String,
+        retryable: bool,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+
+    /// Invalid user input or spec configuration. Always permanent.
+    #[error("validation error: {0}")]
+    ValidationError(String),
+
+    /// A referenced resource (pipeline, run, artifact) does not exist. Permanent.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// An unexpected internal error. Should be investigated; not retried.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl AstraError {
+    /// Returns `true` if the operation that produced this error may succeed on retry.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::ConnectionFailed { retryable, .. } => *retryable,
+            Self::QueryFailed { retryable, .. } => *retryable,
+            Self::StagingFailed { retryable, .. } => *retryable,
+            Self::ValidationError(_) | Self::NotFound(_) | Self::Internal(_) => false,
+        }
+    }
+
+    /// Returns the machine-readable error code for this variant.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::ConnectionFailed { .. } => "CONNECTION_FAILED",
+            Self::QueryFailed { .. } => "QUERY_FAILED",
+            Self::StagingFailed { .. } => "STAGING_FAILED",
+            Self::ValidationError(_) => "VALIDATION_ERROR",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+
+    /// Convenience constructor for a retryable connection failure.
+    pub fn connection_failed_retryable(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::ConnectionFailed {
+            message: message.into(),
+            retryable: true,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Convenience constructor for a permanent connection failure (e.g. bad credentials).
+    pub fn connection_failed_permanent(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::ConnectionFailed {
+            message: message.into(),
+            retryable: false,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Convenience constructor for a permanent query failure (syntax error, missing table).
+    pub fn query_failed_permanent(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::QueryFailed {
+            message: message.into(),
+            retryable: false,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Convenience constructor for a retryable query failure (lock timeout, serialization failure).
+    pub fn query_failed_retryable(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::QueryFailed {
+            message: message.into(),
+            retryable: true,
+            source: Some(Box::new(source)),
+        }
+    }
+}

--- a/crates/astra-metadata/src/lib.rs
+++ b/crates/astra-metadata/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod error;
+pub use error::AstraError;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;


### PR DESCRIPTION
Closes #97

## Summary

- Adds `AstraError` enum to `crates/astra-metadata` with six typed variants: `ConnectionFailed`, `QueryFailed`, `StagingFailed`, `ValidationError`, `NotFound`, `Internal` — each carrying `is_retryable()` and `code()` accessors
- Adds `AppError::Astra(#[from] AstraError)` to the control-plane error type so typed errors propagate directly to HTTP responses with the correct status code (502 for connector failures, 404 for not-found, 400 for validation)
- Enriches HTTP error responses from `{ "error": "..." }` to `{ "error": "...", "code": "...", "retryable": bool }` for all error variants — enables #94 (retry logic) to inspect errors programmatically
- Classifies Postgres connector `connect()` as `ConnectionFailed { retryable: true }` (host may be transiently unavailable)
- Classifies `discover_tables()` column/PK query errors as `QueryFailed { retryable: false }` and missing tables as `NotFound` (permanent — retrying won't help)

## Test plan

- [ ] `cargo build --workspace` passes cleanly
- [ ] `GET /api/v1/pipelines/nonexistent` returns `{"error": "...", "code": "NOT_FOUND", "retryable": false}` with HTTP 404
- [ ] Bad YAML to `POST /api/v1/specs/apply` returns `{"error": "...", "code": "VALIDATION_ERROR", "retryable": false}` with HTTP 400
- [ ] Connector failure with unreachable host surfaces `code: "CONNECTION_FAILED"` and `retryable: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)