### PR TITLE
feat: add saved_connections DB migration

### DIFF
--- a/apps/control-plane/migrations/V2__saved_connections.sql
+++ b/apps/control-plane/migrations/V2__saved_connections.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS saved_connections (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL UNIQUE,
+    kind        TEXT NOT NULL,
+    config_json JSONB NOT NULL DEFAULT '{}',
+    secret_ref  TEXT,
+    created_by  TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Closes #151

## Summary
- Added `apps/control-plane/migrations/V2__saved_connections.sql` via the existing refinery migration framework
- Creates `saved_connections` table with: `id`, `name` (unique), `kind`, `config_json` (JSONB), `secret_ref`, `created_by`, and timestamps
- Purely additive — existing deployments pick up the table on next restart
- Credentials are not stored in `config_json`; `secret_ref` holds a single `env:/file:/vault:` reference consistent with the existing spec secret model

## Test plan
- [ ] `cargo build` compiles cleanly
- [ ] On startup with a Postgres `ASTRA_DATABASE_URL`, refinery runs `V2__saved_connections` and creates the table
- [ ] Existing `V1__initial_schema` tables are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)