### PR TITLE
docs: update CHANGELOG for saved_connections migration (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `saved_connections` table added to the Postgres metadata DB via a new `V2__saved_connections` refinery migration. Stores connection name, kind, non-sensitive config JSON, and an optional `secret_ref` — passwords are never persisted in the database.
 - `AstraError` enum in `astra-metadata` — structured error type with retryable/permanent classification and machine-readable `code()` field (`CONNECTION_FAILED`, `QUERY_FAILED`, `STAGING_FAILED`, `VALIDATION_ERROR`, `NOT_FOUND`, `INTERNAL_ERROR`).
 - `AppError::Astra` variant in the control plane — `AstraError` values propagate directly to HTTP responses with correct status codes (404, 400, 502, 500).
 - HTTP error responses now include `{ "error": "...", "code": "...", "retryable": bool }` instead of just `{ "error": "..." }`.


### PR DESCRIPTION
Follow-up docs for #151 (merged in #167).

## Summary
- Added `CHANGELOG.md` entry under `[Unreleased]` documenting the `saved_connections` DB migration

## Test plan
- [ ] Review entry is accurate against the merged migration in #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)