### PR TITLE
feat: saved connections backend — repository, service, and REST API (#152, #154, #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `ConnectionRepository` trait with Postgres and in-memory implementations — `list_connections`, `get_by_name`, `create`, `update`, `delete`. The Postgres impl is added to `PostgresPipelineRepository` and shares its connection pool; no additional pool is opened.
+- `ConnectionService` — owns CRUD for saved connections and `resolve_spec`, which merges a saved connection's stored fields into a parsed `AstraSpec` before validation. Inline connection fields take precedence over the saved record; `secret_ref` is injected as `password: env:<SECRET_REF>`.
+- `PipelineService::apply_spec` now calls `ConnectionService::resolve_spec` before `spec.validate()`, so specs using `connectionRef` resolve transparently at apply time.
+- REST API for saved connections:
+  - `GET /api/v1/connections` — list all saved connections
+  - `POST /api/v1/connections` — create a connection (201)
+  - `GET /api/v1/connections/:name` — get by name
+  - `PUT /api/v1/connections/:name` — update
+  - `DELETE /api/v1/connections/:name` — delete (204)
+  - Connection `name` is validated against `^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`; invalid names return 400.
 - `saved_connections` table added to the Postgres metadata DB via a new `V2__saved_connections` refinery migration. Stores connection name, kind, non-sensitive config JSON, and an optional `secret_ref` — passwords are never persisted in the database.
 - `connectionRef` field on `source` and `destination` in the `v1alpha1` YAML spec — allows referencing a named saved connection instead of inlining credentials. Mutually exclusive with the inline `connection` block; specifying both returns a new `AmbiguousConnection` validation error.
 - `AstraError` enum in `astra-metadata` — structured error type with retryable/permanent classification and machine-readable `code()` field (`CONNECTION_FAILED`, `QUERY_FAILED`, `STAGING_FAILED`, `VALIDATION_ERROR`, `NOT_FOUND`, `INTERNAL_ERROR`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,8 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -122,6 +124,7 @@ name = "astra-connectors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "astra-metadata",
  "astra-runtime",
  "astra-yaml",
  "flate2",
@@ -183,6 +186,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "uuid",
 ]
 

--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -33,6 +33,7 @@ astra-secrets = { path = "../../crates/astra-secrets" }
 astra-connectors = { path = "../../crates/astra-connectors" }
 astra-runtime = { path = "../../crates/astra-runtime" }
 astra-yaml = { path = "../../crates/astra-yaml" }
+serde_yaml.workspace = true
 
 [dev-dependencies]
 testcontainers = "0.17"

--- a/apps/control-plane/src/http/connections.rs
+++ b/apps/control-plane/src/http/connections.rs
@@ -1,0 +1,102 @@
+use crate::{
+    error::{AppError, NotFoundError},
+    models::api::{SavedConnectionRequest, SavedConnectionResponse, SavedConnectionsResponse},
+    repositories::CreateSavedConnectionInput,
+    state::AppState,
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+
+/// Validates that `name` matches `^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`.
+fn validate_name(name: &str) -> Result<(), AppError> {
+    let len = name.len();
+    let is_alnum = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit();
+    let valid = (2..=63).contains(&len)
+        && name.chars().next().map(is_alnum).unwrap_or(false)
+        && name.chars().last().map(is_alnum).unwrap_or(false)
+        && name.chars().all(|c| is_alnum(c) || c == '-');
+    if !valid {
+        return Err(AppError::BadRequest(format!(
+            "connection name '{}' is invalid: must match ^[a-z0-9][a-z0-9-]{{0,61}}[a-z0-9]$",
+            name
+        )));
+    }
+    Ok(())
+}
+
+fn build_input(req: SavedConnectionRequest) -> CreateSavedConnectionInput {
+    let config_json = serde_json::json!({
+        "host": req.host,
+        "port": req.port,
+        "database": req.database,
+        "username": req.username,
+    });
+    CreateSavedConnectionInput {
+        name: req.name,
+        kind: req.kind,
+        config_json,
+        secret_ref: req.secret_ref,
+        created_by: None,
+    }
+}
+
+pub async fn list_connections(
+    State(state): State<AppState>,
+) -> Result<Json<SavedConnectionsResponse>, AppError> {
+    let records = state.connection_service.list_connections().await?;
+    let connections = records
+        .into_iter()
+        .map(SavedConnectionResponse::try_from)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(Json(SavedConnectionsResponse { connections }))
+}
+
+pub async fn create_connection(
+    State(state): State<AppState>,
+    Json(request): Json<SavedConnectionRequest>,
+) -> Result<(StatusCode, Json<SavedConnectionResponse>), AppError> {
+    validate_name(&request.name)?;
+    let input = build_input(request);
+    let record = state.connection_service.create_connection(input).await?;
+    let response = SavedConnectionResponse::try_from(record)?;
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+pub async fn get_connection(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<SavedConnectionResponse>, AppError> {
+    let record = state
+        .connection_service
+        .get_connection(&name)
+        .await?
+        .ok_or_else(|| NotFoundError(name.clone()))?;
+    let response = SavedConnectionResponse::try_from(record)?;
+    Ok(Json(response))
+}
+
+pub async fn update_connection(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(request): Json<SavedConnectionRequest>,
+) -> Result<Json<SavedConnectionResponse>, AppError> {
+    validate_name(&request.name)?;
+    let input = build_input(request);
+    let record = state
+        .connection_service
+        .update_connection(&name, input)
+        .await?;
+    let response = SavedConnectionResponse::try_from(record)?;
+    Ok(Json(response))
+}
+
+pub async fn delete_connection(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, AppError> {
+    state.connection_service.delete_connection(&name).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -1,3 +1,4 @@
+pub mod connections;
 pub mod health;
 pub mod pipelines;
 
@@ -62,5 +63,16 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/api/v1/examples/postgres-to-warehouse",
             get(health::example_postgres_to_warehouse),
+        )
+        // Saved connections
+        .route(
+            "/api/v1/connections",
+            get(connections::list_connections).post(connections::create_connection),
+        )
+        .route(
+            "/api/v1/connections/:name",
+            get(connections::get_connection)
+                .put(connections::update_connection)
+                .delete(connections::delete_connection),
         )
 }

--- a/apps/control-plane/src/main.rs
+++ b/apps/control-plane/src/main.rs
@@ -15,10 +15,12 @@ use api::ApiModule;
 use config::ConfigModule;
 use metadata::MetadataModule;
 use repositories::{
-    memory::InMemoryPipelineRepository, postgres::PostgresPipelineRepository, PipelineRepository,
+    memory::{InMemoryConnectionRepository, InMemoryPipelineRepository},
+    postgres::PostgresPipelineRepository,
+    ConnectionRepository, PipelineRepository,
 };
 use scheduler::SchedulerModule;
-use services::PipelineService;
+use services::{ConnectionService, PipelineService};
 use state::AppState;
 use std::{net::SocketAddr, sync::Arc};
 
@@ -35,9 +37,13 @@ async fn main() -> anyhow::Result<()> {
     let api = ApiModule::new();
     let scheduler = SchedulerModule::new();
     let metadata = MetadataModule::new();
-    let repository = build_repository(&config).await;
-    let pipeline_service = Arc::new(PipelineService::new(repository));
-    let state = AppState::new(pipeline_service);
+    let (pipeline_repo, connection_repo) = build_repositories(&config).await;
+    let connection_service = Arc::new(ConnectionService::new(connection_repo));
+    let pipeline_service = Arc::new(PipelineService::new(
+        pipeline_repo,
+        connection_service.clone(),
+    ));
+    let state = AppState::new(pipeline_service, connection_service);
     let app = app::build_router(state);
 
     tracing::info!(
@@ -56,12 +62,15 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn build_repository(config: &ConfigModule) -> Arc<dyn PipelineRepository> {
+async fn build_repositories(
+    config: &ConfigModule,
+) -> (Arc<dyn PipelineRepository>, Arc<dyn ConnectionRepository>) {
     if let Some(database_url) = config.database_url.as_deref() {
         match PostgresPipelineRepository::connect(database_url).await {
             Ok(repository) => {
                 tracing::info!("using Postgres pipeline repository");
-                return Arc::new(repository);
+                let repo = Arc::new(repository);
+                return (repo.clone(), repo);
             }
             Err(error) => {
                 tracing::warn!(
@@ -74,5 +83,8 @@ async fn build_repository(config: &ConfigModule) -> Arc<dyn PipelineRepository> 
         tracing::info!("ASTRA_DATABASE_URL not set; using in-memory pipeline repository");
     }
 
-    Arc::new(InMemoryPipelineRepository::default())
+    (
+        Arc::new(InMemoryPipelineRepository::default()),
+        Arc::new(InMemoryConnectionRepository::default()),
+    )
 }

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -1,5 +1,6 @@
 use crate::repositories::{
-    PipelineRecord, PipelineRunRecord, StagedArtifactRecord, TableExecutionRecord,
+    PipelineRecord, PipelineRunRecord, SavedConnectionRecord, StagedArtifactRecord,
+    TableExecutionRecord,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -234,4 +235,75 @@ pub struct UpsertTableExecutionRequest {
     pub checkpoint_last_chunk_key: Option<String>,
     #[serde(default)]
     pub checkpoint_completed: Option<bool>,
+}
+
+// ── Saved Connections ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SavedConnectionRequest {
+    pub name: String,
+    pub kind: String,
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    #[serde(default)]
+    pub secret_ref: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SavedConnectionResponse {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    pub secret_ref: Option<String>,
+    pub created_by: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl TryFrom<SavedConnectionRecord> for SavedConnectionResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(r: SavedConnectionRecord) -> anyhow::Result<Self> {
+        let cfg = &r.config_json;
+        let host = cfg
+            .get("host")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let port = cfg.get("port").and_then(|v| v.as_u64()).unwrap_or(5432) as u16;
+        let database = cfg
+            .get("database")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let username = cfg
+            .get("username")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        Ok(Self {
+            id: r.id.to_string(),
+            name: r.name,
+            kind: r.kind,
+            host,
+            port,
+            database,
+            username,
+            secret_ref: r.secret_ref,
+            created_by: r.created_by,
+            created_at: r.created_at.to_rfc3339(),
+            updated_at: r.updated_at.to_rfc3339(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SavedConnectionsResponse {
+    pub connections: Vec<SavedConnectionResponse>,
 }

--- a/apps/control-plane/src/repositories/connection_repository.rs
+++ b/apps/control-plane/src/repositories/connection_repository.rs
@@ -1,0 +1,41 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct SavedConnectionRecord {
+    pub id: Uuid,
+    pub name: String,
+    pub kind: String,
+    pub config_json: Value,
+    pub secret_ref: Option<String>,
+    pub created_by: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSavedConnectionInput {
+    pub name: String,
+    pub kind: String,
+    pub config_json: Value,
+    pub secret_ref: Option<String>,
+    pub created_by: Option<String>,
+}
+
+#[async_trait]
+pub trait ConnectionRepository: Send + Sync {
+    async fn list_connections(&self) -> anyhow::Result<Vec<SavedConnectionRecord>>;
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<SavedConnectionRecord>>;
+    async fn create(
+        &self,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord>;
+    async fn update(
+        &self,
+        name: &str,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord>;
+    async fn delete(&self, name: &str) -> anyhow::Result<()>;
+}

--- a/apps/control-plane/src/repositories/memory/connection_repository.rs
+++ b/apps/control-plane/src/repositories/memory/connection_repository.rs
@@ -1,0 +1,76 @@
+use crate::repositories::connection_repository::{
+    ConnectionRepository, CreateSavedConnectionInput, SavedConnectionRecord,
+};
+use anyhow::Context;
+use async_trait::async_trait;
+use chrono::Utc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+#[derive(Default, Clone)]
+pub struct InMemoryConnectionRepository {
+    inner: Arc<RwLock<HashMap<String, SavedConnectionRecord>>>,
+}
+
+#[async_trait]
+impl ConnectionRepository for InMemoryConnectionRepository {
+    async fn list_connections(&self) -> anyhow::Result<Vec<SavedConnectionRecord>> {
+        let guard = self.inner.read().await;
+        let mut records: Vec<_> = guard.values().cloned().collect();
+        records.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(records)
+    }
+
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<SavedConnectionRecord>> {
+        let guard = self.inner.read().await;
+        Ok(guard.get(name).cloned())
+    }
+
+    async fn create(
+        &self,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        let mut guard = self.inner.write().await;
+        if guard.contains_key(&input.name) {
+            anyhow::bail!("connection '{}' already exists", input.name);
+        }
+        let now = Utc::now();
+        let record = SavedConnectionRecord {
+            id: Uuid::new_v4(),
+            name: input.name.clone(),
+            kind: input.kind,
+            config_json: input.config_json,
+            secret_ref: input.secret_ref,
+            created_by: input.created_by,
+            created_at: now,
+            updated_at: now,
+        };
+        guard.insert(input.name, record.clone());
+        Ok(record)
+    }
+
+    async fn update(
+        &self,
+        name: &str,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        let mut guard = self.inner.write().await;
+        let existing = guard
+            .get_mut(name)
+            .with_context(|| format!("connection '{name}' not found"))?;
+        existing.kind = input.kind;
+        existing.config_json = input.config_json;
+        existing.secret_ref = input.secret_ref;
+        existing.updated_at = Utc::now();
+        Ok(existing.clone())
+    }
+
+    async fn delete(&self, name: &str) -> anyhow::Result<()> {
+        let mut guard = self.inner.write().await;
+        if guard.remove(name).is_none() {
+            anyhow::bail!("connection '{name}' not found");
+        }
+        Ok(())
+    }
+}

--- a/apps/control-plane/src/repositories/memory/mod.rs
+++ b/apps/control-plane/src/repositories/memory/mod.rs
@@ -1,3 +1,5 @@
+mod connection_repository;
 mod pipeline_repository;
 
+pub use connection_repository::InMemoryConnectionRepository;
 pub use pipeline_repository::InMemoryPipelineRepository;

--- a/apps/control-plane/src/repositories/mod.rs
+++ b/apps/control-plane/src/repositories/mod.rs
@@ -1,8 +1,12 @@
+pub mod connection_repository;
 pub mod memory;
 pub mod pipeline_repository;
 pub mod postgres;
 
-pub use memory::InMemoryPipelineRepository;
+pub use connection_repository::{
+    ConnectionRepository, CreateSavedConnectionInput, SavedConnectionRecord,
+};
+pub use memory::{InMemoryConnectionRepository, InMemoryPipelineRepository};
 pub use pipeline_repository::{
     AppliedPipelineRecord, ApplySpecRecord, CreatePipelineRunRecord, PipelineRecord,
     PipelineRepository, PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,

--- a/apps/control-plane/src/repositories/postgres.rs
+++ b/apps/control-plane/src/repositories/postgres.rs
@@ -1,6 +1,9 @@
 use crate::{
     error::NotFoundError,
     repositories::{
+        connection_repository::{
+            ConnectionRepository, CreateSavedConnectionInput, SavedConnectionRecord,
+        },
         AppliedPipelineRecord, ApplySpecRecord, CreatePipelineRunRecord, PipelineRecord,
         PipelineRepository, PipelineRunRecord, RecordStagedArtifactRecord, StagedArtifactRecord,
         TableExecutionRecord, UpsertTableExecutionRecord,
@@ -677,4 +680,138 @@ fn hash_content(content: &str) -> String {
 
 fn parse_pipeline_status(status: String) -> anyhow::Result<PipelineStatus> {
     PipelineStatus::from_str(&status).map_err(|err| anyhow!(err))
+}
+
+#[async_trait]
+impl ConnectionRepository for PostgresPipelineRepository {
+    async fn list_connections(&self) -> anyhow::Result<Vec<SavedConnectionRecord>> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to obtain pool connection")?;
+        let rows = client
+            .query(
+                r#"
+                SELECT id, name, kind, config_json, secret_ref, created_by, created_at, updated_at
+                FROM saved_connections
+                ORDER BY name ASC
+                "#,
+                &[],
+            )
+            .await
+            .context("failed to list saved connections")?;
+        rows.into_iter().map(map_connection_row).collect()
+    }
+
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<SavedConnectionRecord>> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to obtain pool connection")?;
+        let row = client
+            .query_opt(
+                r#"
+                SELECT id, name, kind, config_json, secret_ref, created_by, created_at, updated_at
+                FROM saved_connections
+                WHERE name = $1
+                "#,
+                &[&name],
+            )
+            .await
+            .context("failed to get saved connection by name")?;
+        row.map(map_connection_row).transpose()
+    }
+
+    async fn create(
+        &self,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to obtain pool connection")?;
+        let row = client
+            .query_one(
+                r#"
+                INSERT INTO saved_connections (name, kind, config_json, secret_ref, created_by)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id, name, kind, config_json, secret_ref, created_by, created_at, updated_at
+                "#,
+                &[
+                    &input.name,
+                    &input.kind,
+                    &Json(&input.config_json),
+                    &input.secret_ref,
+                    &input.created_by,
+                ],
+            )
+            .await
+            .context("failed to create saved connection")?;
+        map_connection_row(row)
+    }
+
+    async fn update(
+        &self,
+        name: &str,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to obtain pool connection")?;
+        let row = client
+            .query_opt(
+                r#"
+                UPDATE saved_connections
+                SET kind = $2, config_json = $3, secret_ref = $4, updated_at = NOW()
+                WHERE name = $1
+                RETURNING id, name, kind, config_json, secret_ref, created_by, created_at, updated_at
+                "#,
+                &[
+                    &name,
+                    &input.kind,
+                    &Json(&input.config_json),
+                    &input.secret_ref,
+                ],
+            )
+            .await
+            .context("failed to update saved connection")?;
+        row.map(map_connection_row)
+            .transpose()?
+            .ok_or_else(|| anyhow::anyhow!(NotFoundError(name.to_string())))
+    }
+
+    async fn delete(&self, name: &str) -> anyhow::Result<()> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to obtain pool connection")?;
+        let count = client
+            .execute("DELETE FROM saved_connections WHERE name = $1", &[&name])
+            .await
+            .context("failed to delete saved connection")?;
+        if count == 0 {
+            anyhow::bail!(NotFoundError(name.to_string()));
+        }
+        Ok(())
+    }
+}
+
+fn map_connection_row(row: Row) -> anyhow::Result<SavedConnectionRecord> {
+    let Json(config_json) = row.try_get::<_, Json<serde_json::Value>>("config_json")?;
+    Ok(SavedConnectionRecord {
+        id: row.try_get("id")?,
+        name: row.try_get("name")?,
+        kind: row.try_get("kind")?,
+        config_json,
+        secret_ref: row.try_get("secret_ref")?,
+        created_by: row.try_get("created_by")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+    })
 }

--- a/apps/control-plane/src/services/connection_service.rs
+++ b/apps/control-plane/src/services/connection_service.rs
@@ -1,0 +1,138 @@
+use crate::repositories::{
+    ConnectionRepository, CreateSavedConnectionInput, SavedConnectionRecord,
+};
+use astra_yaml::AstraSpec;
+use std::sync::Arc;
+
+pub struct ConnectionService {
+    repo: Arc<dyn ConnectionRepository>,
+}
+
+impl ConnectionService {
+    pub fn new(repo: Arc<dyn ConnectionRepository>) -> Self {
+        Self { repo }
+    }
+
+    /// Resolves `connectionRef` in source and destination.
+    ///
+    /// For each side that has a `connection_ref` set, the named connection is
+    /// looked up, its `config_json` fields are merged into the inline
+    /// `connection` map, and `connection_ref` is cleared so that downstream
+    /// validation sees a fully-specified connection block.
+    pub async fn resolve_spec(&self, mut spec: AstraSpec) -> anyhow::Result<AstraSpec> {
+        if let Some(ref name) = spec.source.connection_ref.clone() {
+            let record = self.repo.get_by_name(name).await?.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "connectionRef '{}' not found in saved connections (source)",
+                    name
+                )
+            })?;
+
+            merge_connection_fields(&mut spec.source.connection, &record);
+            spec.source.connection_ref = None;
+        }
+
+        if let Some(ref name) = spec.destination.connection_ref.clone() {
+            let record = self.repo.get_by_name(name).await?.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "connectionRef '{}' not found in saved connections (destination)",
+                    name
+                )
+            })?;
+
+            let conn = spec
+                .destination
+                .connection
+                .get_or_insert_with(Default::default);
+            merge_connection_fields(conn, &record);
+            spec.destination.connection_ref = None;
+        }
+
+        Ok(spec)
+    }
+
+    pub async fn list_connections(&self) -> anyhow::Result<Vec<SavedConnectionRecord>> {
+        self.repo.list_connections().await
+    }
+
+    pub async fn get_connection(
+        &self,
+        name: &str,
+    ) -> anyhow::Result<Option<SavedConnectionRecord>> {
+        self.repo.get_by_name(name).await
+    }
+
+    pub async fn create_connection(
+        &self,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        self.repo.create(input).await
+    }
+
+    pub async fn update_connection(
+        &self,
+        name: &str,
+        input: CreateSavedConnectionInput,
+    ) -> anyhow::Result<SavedConnectionRecord> {
+        self.repo.update(name, input).await
+    }
+
+    pub async fn delete_connection(&self, name: &str) -> anyhow::Result<()> {
+        self.repo.delete(name).await
+    }
+}
+
+/// Merges fields from a saved connection record into a YAML connection map.
+///
+/// All fields from `config_json` are inserted (existing inline fields take
+/// precedence — they are not overwritten).  When the connection has a
+/// `secret_ref`, it is injected as `password: env:<SECRET_REF>` if no
+/// `password` key is already present.
+fn merge_connection_fields(
+    connection: &mut std::collections::BTreeMap<String, serde_yaml::Value>,
+    record: &SavedConnectionRecord,
+) {
+    if let Some(obj) = record.config_json.as_object() {
+        for (key, val) in obj {
+            // Do not overwrite fields the user has set inline.
+            if connection.contains_key(key) {
+                continue;
+            }
+            let yaml_val = json_to_yaml(val);
+            connection.insert(key.clone(), yaml_val);
+        }
+    }
+
+    if let Some(ref secret_ref) = record.secret_ref {
+        connection
+            .entry("password".to_string())
+            .or_insert_with(|| serde_yaml::Value::String(format!("env:{}", secret_ref)));
+    }
+}
+
+fn json_to_yaml(val: &serde_json::Value) -> serde_yaml::Value {
+    match val {
+        serde_json::Value::Null => serde_yaml::Value::Null,
+        serde_json::Value::Bool(b) => serde_yaml::Value::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_yaml::Value::Number(serde_yaml::Number::from(i))
+            } else if let Some(f) = n.as_f64() {
+                serde_yaml::Value::Number(serde_yaml::Number::from(f))
+            } else {
+                serde_yaml::Value::String(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => serde_yaml::Value::String(s.clone()),
+        serde_json::Value::Array(arr) => {
+            serde_yaml::Value::Sequence(arr.iter().map(json_to_yaml).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mapping = map
+                .iter()
+                .map(|(k, v)| (serde_yaml::Value::String(k.clone()), json_to_yaml(v)))
+                .collect();
+            serde_yaml::Value::Mapping(mapping)
+        }
+    }
+}

--- a/apps/control-plane/src/services/mod.rs
+++ b/apps/control-plane/src/services/mod.rs
@@ -1,3 +1,5 @@
+pub mod connection_service;
 pub mod pipeline_service;
 
+pub use connection_service::ConnectionService;
 pub use pipeline_service::PipelineService;

--- a/apps/control-plane/src/services/pipeline_service.rs
+++ b/apps/control-plane/src/services/pipeline_service.rs
@@ -8,6 +8,7 @@ use crate::{
         ApplySpecRecord, CreatePipelineRunRecord, PipelineRepository, RecordStagedArtifactRecord,
         UpsertTableExecutionRecord,
     },
+    services::ConnectionService,
 };
 use astra_metadata::PipelineStatus;
 use chrono::Utc;
@@ -16,11 +17,18 @@ use uuid::Uuid;
 
 pub struct PipelineService {
     repository: Arc<dyn PipelineRepository>,
+    connection_service: Arc<ConnectionService>,
 }
 
 impl PipelineService {
-    pub fn new(repository: Arc<dyn PipelineRepository>) -> Self {
-        Self { repository }
+    pub fn new(
+        repository: Arc<dyn PipelineRepository>,
+        connection_service: Arc<ConnectionService>,
+    ) -> Self {
+        Self {
+            repository,
+            connection_service,
+        }
     }
 
     pub async fn list_pipelines(&self) -> anyhow::Result<Vec<PipelineSummaryResponse>> {
@@ -37,6 +45,7 @@ impl PipelineService {
             anyhow::bail!(BadRequestError("yaml must not be empty".to_string()));
         }
         let spec = astra_yaml::AstraSpec::parse_yaml(&yaml)?;
+        let spec = self.connection_service.resolve_spec(spec).await?;
         spec.validate()?;
         if spec.requests_cdc() {
             anyhow::bail!(

--- a/apps/control-plane/src/state.rs
+++ b/apps/control-plane/src/state.rs
@@ -1,13 +1,20 @@
-use crate::services::PipelineService;
+use crate::services::{ConnectionService, PipelineService};
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pipeline_service: Arc<PipelineService>,
+    pub connection_service: Arc<ConnectionService>,
 }
 
 impl AppState {
-    pub fn new(pipeline_service: Arc<PipelineService>) -> Self {
-        Self { pipeline_service }
+    pub fn new(
+        pipeline_service: Arc<PipelineService>,
+        connection_service: Arc<ConnectionService>,
+    ) -> Self {
+        Self {
+            pipeline_service,
+            connection_service,
+        }
     }
 }

--- a/apps/control-plane/tests/checkpoint_metadata.rs
+++ b/apps/control-plane/tests/checkpoint_metadata.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use astra_control_plane::{
     models::api::{TableExecutionResponse, UpsertTableExecutionRequest},
-    services::PipelineService,
+    repositories::InMemoryConnectionRepository,
+    services::{ConnectionService, PipelineService},
     InMemoryPipelineRepository,
 };
 use astra_metadata::PipelineStatus;
@@ -11,7 +12,9 @@ use astra_metadata::PipelineStatus;
 #[tokio::test]
 async fn table_execution_checkpoint_metadata_round_trips_via_service() -> Result<()> {
     let repository = Arc::new(InMemoryPipelineRepository::default());
-    let service = PipelineService::new(repository);
+    let conn_repo = Arc::new(InMemoryConnectionRepository::default());
+    let connection_service = Arc::new(ConnectionService::new(conn_repo));
+    let service = PipelineService::new(repository, connection_service);
 
     let yaml = r#"
 version: v1alpha1
@@ -129,7 +132,9 @@ runtime:
 #[tokio::test]
 async fn delete_and_disable_pipeline_via_service() -> Result<()> {
     let repository = Arc::new(InMemoryPipelineRepository::default());
-    let service = PipelineService::new(repository);
+    let conn_repo = Arc::new(InMemoryConnectionRepository::default());
+    let connection_service = Arc::new(ConnectionService::new(conn_repo));
+    let service = PipelineService::new(repository, connection_service);
 
     let yaml = r#"
 version: v1alpha1

--- a/website/docs/control-plane/api.md
+++ b/website/docs/control-plane/api.md
@@ -166,6 +166,76 @@ List all table-level execution records for a run.
 
 ---
 
+## Saved Connections
+
+Saved connections store non-sensitive database credentials (host, port, database, username) and an optional `secret_ref` so that pipeline specs can reference them by name instead of inlining credentials. Passwords are never stored in the database.
+
+### `GET /api/v1/connections`
+
+List all saved connections.
+
+**Response:**
+
+```json
+{
+  "connections": [
+    {
+      "id": "a1b2c3d4-...",
+      "name": "prod-postgres",
+      "kind": "postgres",
+      "host": "db.example.com",
+      "port": 5432,
+      "database": "app",
+      "username": "replicator",
+      "secret_ref": "env:POSTGRES_PASSWORD",
+      "created_by": null,
+      "created_at": "2026-04-07T10:00:00Z",
+      "updated_at": "2026-04-07T10:00:00Z"
+    }
+  ]
+}
+```
+
+### `POST /api/v1/connections`
+
+Create a new saved connection. Returns `201 Created`.
+
+**Body:**
+
+```json
+{
+  "name": "prod-postgres",
+  "kind": "postgres",
+  "host": "db.example.com",
+  "port": 5432,
+  "database": "app",
+  "username": "replicator",
+  "secret_ref": "env:POSTGRES_PASSWORD"
+}
+```
+
+`secret_ref` is optional. `name` must match `^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`.
+
+**Response:** the created connection record (same shape as the list item above).
+
+### `GET /api/v1/connections/:name`
+
+Get a single saved connection by name.
+
+**Response:** the connection record, or `404` if not found.
+
+### `PUT /api/v1/connections/:name`
+
+Replace the fields of an existing saved connection. Same body shape as `POST`. Returns the updated record or `404` if not found.
+
+### `DELETE /api/v1/connections/:name`
+
+Delete a saved connection by name. Returns `204 No Content`, or `404` if not found.
+
+> **Note:** Deleting a saved connection does not affect pipelines that were already applied — `connectionRef` is resolved and inlined at apply time, so existing pipeline specs are unaffected.
+
+---
+
 ## Spec apply
 
 ### `POST /api/v1/specs/apply`
@@ -218,16 +288,19 @@ All errors follow this shape:
 ```json
 {
   "error": "human-readable message",
-  "details": ["optional", "field-level", "errors"]
+  "code": "NOT_FOUND",
+  "retryable": false
 }
 ```
 
-| HTTP status | Meaning |
-|---|---|
-| `400` | Validation error or bad request body |
-| `404` | Resource not found |
-| `409` | Conflict (e.g., duplicate pipeline name) |
-| `500` | Internal server error |
+| HTTP status | `code` | Meaning |
+|---|---|---|
+| `400` | `BAD_REQUEST` / `VALIDATION_ERROR` | Validation error, bad request body, or invalid name format |
+| `404` | `NOT_FOUND` | Resource not found |
+| `502` | `CONNECTION_FAILED` / `QUERY_FAILED` | Upstream connector error |
+| `500` | `INTERNAL_ERROR` | Internal server error |
+
+`retryable: true` is set for transient errors (e.g., connection failures) where the client can safely retry.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the backend for saved database connections (part of #143), closing issues #152, #154, and #155.

- **`ConnectionRepository` trait** (`connection_repository.rs`) — `list_connections`, `get_by_name`, `create`, `update`, `delete` with `SavedConnectionRecord` and `CreateSavedConnectionInput` types
- **Postgres impl** — added to `PostgresPipelineRepository` so the same pool is shared; `Arc<PostgresPipelineRepository>` is coerced to both `Arc<dyn PipelineRepository>` and `Arc<dyn ConnectionRepository>` in `main.rs` without opening a second pool
- **In-memory impl** — `InMemoryConnectionRepository` (mirrors existing pipeline repo pattern) used as the dev/test fallback
- **`ConnectionService`** — owns CRUD delegation and `resolve_spec`, which merges a saved connection's `config_json` fields into the inline `connection` map of an `AstraSpec` before validation; inline fields take precedence; `secret_ref` is injected as `password: env:<SECRET_REF>`
- **`PipelineService::apply_spec`** — now calls `connection_service.resolve_spec()` before `spec.validate()` so `connectionRef` fields resolve transparently at apply time
- **REST API** (5 endpoints):
  - `GET /api/v1/connections` — list
  - `POST /api/v1/connections` — create (201)
  - `GET /api/v1/connections/:name` — get by name
  - `PUT /api/v1/connections/:name` — update
  - `DELETE /api/v1/connections/:name` — delete (204)
  - Name validated against `^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$` (400 on failure)
- `serde_yaml` promoted from `dev-dependencies` to regular dependencies for the control-plane crate (needed for `resolve_spec` to write into `Source.connection: BTreeMap<String, serde_yaml::Value>`)

## Test plan

- [ ] `cargo test -p astra-control-plane --test checkpoint_metadata` — existing in-memory tests pass with updated `PipelineService::new` signature
- [ ] `cargo build -p astra-control-plane` — clean build, no warnings
- [ ] `cargo clippy -p astra-control-plane` — clean
- [ ] Manual: start control-plane in-memory mode, `POST /api/v1/connections`, then `GET /api/v1/connections` to confirm round-trip
- [ ] Manual: `POST /api/v1/specs/apply` with a spec using `connectionRef` pointing to a saved connection — verify it resolves before validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)