### PR TITLE
feat: add test-connection CLI command and POST /api/v1/connections/test (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `test-connection` CLI command — validates source or destination connectivity before running a pipeline. Runs `SELECT 1` against the configured Postgres database, reports round-trip latency, and verifies that every table in `capture.tables` exists. Usage: `astra test-connection <spec.yaml> [--target source|destination]`.
+- `POST /api/v1/connections/test` API endpoint — accepts inline connection config (host, port, database, username, optional passwordRef/sslMode, optional tables list) and returns `{ "status": "ok", "latency_ms": N }` or `{ "status": "error", "message": "..." }`. Supports an optional `tables` array to verify table existence in `information_schema.tables`. Currently supports `"postgres"` kind only.
+- `ConnectionTestResult` type in `astra-connectors` — structured result shared by the CLI and connector layer; carries status, latency, optional error message, and a list of missing tables.
+- `PostgresSource::test_connection` method — tests the source connection and verifies all configured tables exist.
+- `PostgresDestinationLoader::test_connection` method — tests the destination connection reachability.
 - `ConnectionRepository` trait with Postgres and in-memory implementations — `list_connections`, `get_by_name`, `create`, `update`, `delete`. The Postgres impl is added to `PostgresPipelineRepository` and shares its connection pool; no additional pool is opened.
 - `ConnectionService` — owns CRUD for saved connections and `resolve_spec`, which merges a saved connection's stored fields into a parsed `AstraSpec` before validation. Inline connection fields take precedence over the saved record; `secret_ref` is injected as `password: env:<SECRET_REF>`.
 - `PipelineService::apply_spec` now calls `ConnectionService::resolve_spec` before `spec.validate()`, so specs using `connectionRef` resolve transparently at apply time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ ASTRA_DATABASE_URL=postgres://astra:astra@localhost:5432/astra cargo run -p astr
 ### CLI
 ```bash
 cargo run -p astra -- validate examples/postgres-to-warehouse.astra.yaml
+cargo run -p astra -- test-connection examples/postgres-to-warehouse.astra.yaml --target source
 cargo run -p astra -- discover-source examples/postgres-to-warehouse.astra.yaml
 cargo run -p astra -- snapshot-to-local-staging examples/postgres-to-warehouse.astra.yaml
 cargo run -p astra -- execute-local-snapshot examples/postgres-to-warehouse.astra.yaml

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -54,6 +54,13 @@ pub enum Command {
         #[arg(long)]
         control_plane_url: Option<String>,
     },
+    /// Test connectivity for the source or destination in an Astra YAML spec
+    TestConnection {
+        file: String,
+        /// Which side to test: "source" or "destination"
+        #[arg(long, default_value = "source")]
+        target: String,
+    },
     /// Run the narrow local snapshot happy path end to end: snapshot -> local staging -> Postgres load
     ExecuteLocalSnapshot {
         file: String,
@@ -75,6 +82,36 @@ pub enum Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_test_connection_defaults() {
+        let cli = Cli::parse_from(["astra", "test-connection", "examples/spec.yaml"]);
+        assert_eq!(
+            cli.command,
+            Command::TestConnection {
+                file: "examples/spec.yaml".to_string(),
+                target: "source".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_test_connection_destination_target() {
+        let cli = Cli::parse_from([
+            "astra",
+            "test-connection",
+            "examples/spec.yaml",
+            "--target",
+            "destination",
+        ]);
+        assert_eq!(
+            cli.command,
+            Command::TestConnection {
+                file: "examples/spec.yaml".to_string(),
+                target: "destination".to_string(),
+            }
+        );
+    }
 
     #[test]
     fn parses_snapshot_to_local_staging_flags() {

--- a/apps/cli/src/commands.rs
+++ b/apps/cli/src/commands.rs
@@ -85,6 +85,53 @@ pub async fn discover_source(file: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub async fn test_connection(file: &str, target: &str) -> anyhow::Result<()> {
+    let spec = AstraSpec::from_file(file)?;
+    spec.validate()?;
+
+    let result = match target {
+        "source" => {
+            if spec.source.kind != "postgres" {
+                bail!(
+                    "test-connection: source kind '{}' is not supported yet",
+                    spec.source.kind
+                );
+            }
+            let source = PostgresSource::from_spec(&spec)?;
+            source.test_connection().await
+        }
+        "destination" => {
+            if spec.destination.kind != "postgres" {
+                bail!(
+                    "test-connection: destination kind '{}' is not supported yet",
+                    spec.destination.kind
+                );
+            }
+            let loader = PostgresDestinationLoader::from_spec(&spec)?;
+            loader.test_connection().await
+        }
+        other => bail!(
+            "unknown target '{}'; expected 'source' or 'destination'",
+            other
+        ),
+    };
+
+    if result.status == "ok" {
+        println!("status: ok\nlatency_ms: {}", result.latency_ms.unwrap_or(0));
+    } else {
+        eprintln!(
+            "status: error\nmessage: {}",
+            result.message.as_deref().unwrap_or("unknown error")
+        );
+        if !result.missing_tables.is_empty() {
+            eprintln!("missing_tables: {}", result.missing_tables.join(", "));
+        }
+        bail!("connection test failed");
+    }
+
+    Ok(())
+}
+
 pub async fn snapshot_to_local_staging(
     file: &str,
     max_rows_per_table: Option<u64>,

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -22,6 +22,7 @@ async fn dispatch(command: Command) -> anyhow::Result<()> {
         Command::Validate { file } => commands::validate(&file),
         Command::Apply { file } => commands::apply(&file),
         Command::DiscoverSource { file } => commands::discover_source(&file).await,
+        Command::TestConnection { file, target } => commands::test_connection(&file, &target).await,
         Command::SnapshotToLocalStaging {
             file,
             max_rows_per_table,

--- a/apps/control-plane/src/http/connections.rs
+++ b/apps/control-plane/src/http/connections.rs
@@ -1,9 +1,13 @@
 use crate::{
     error::{AppError, NotFoundError},
-    models::api::{SavedConnectionRequest, SavedConnectionResponse, SavedConnectionsResponse},
+    models::api::{
+        ConnectionTestRequest, ConnectionTestResponse, SavedConnectionRequest,
+        SavedConnectionResponse, SavedConnectionsResponse,
+    },
     repositories::CreateSavedConnectionInput,
     state::AppState,
 };
+use astra_connectors::{test_postgres_connection, PostgresConnectionConfig};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -99,4 +103,34 @@ pub async fn delete_connection(
 ) -> Result<StatusCode, AppError> {
     state.connection_service.delete_connection(&name).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn test_connection(
+    Json(req): Json<ConnectionTestRequest>,
+) -> Result<Json<ConnectionTestResponse>, AppError> {
+    if req.kind != "postgres" {
+        return Err(AppError::BadRequest(format!(
+            "connection kind '{}' is not supported; only 'postgres' is currently supported",
+            req.kind
+        )));
+    }
+
+    let config = PostgresConnectionConfig {
+        host: req.host,
+        port: req.port,
+        database: req.database,
+        username: req.username,
+        password_ref: req.password_ref,
+        ssl_mode: req.ssl_mode,
+        application_name: None,
+    };
+
+    let result = test_postgres_connection(&config, &req.tables).await;
+
+    Ok(Json(ConnectionTestResponse {
+        status: result.status,
+        latency_ms: result.latency_ms,
+        message: result.message,
+        missing_tables: result.missing_tables,
+    }))
 }

--- a/apps/control-plane/src/http/mod.rs
+++ b/apps/control-plane/src/http/mod.rs
@@ -70,6 +70,10 @@ pub fn routes() -> Router<AppState> {
             get(connections::list_connections).post(connections::create_connection),
         )
         .route(
+            "/api/v1/connections/test",
+            post(connections::test_connection),
+        )
+        .route(
             "/api/v1/connections/:name",
             get(connections::get_connection)
                 .put(connections::update_connection)

--- a/apps/control-plane/src/models/api.rs
+++ b/apps/control-plane/src/models/api.rs
@@ -307,3 +307,39 @@ impl TryFrom<SavedConnectionRecord> for SavedConnectionResponse {
 pub struct SavedConnectionsResponse {
     pub connections: Vec<SavedConnectionResponse>,
 }
+
+// ── Connection Test ──────────────────────────────────────────────────────────
+
+/// Request body for `POST /api/v1/connections/test`.
+#[derive(Debug, Deserialize)]
+pub struct ConnectionTestRequest {
+    /// Connector kind; currently only `"postgres"` is supported.
+    pub kind: String,
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    /// Password reference in `env:VAR_NAME` format.
+    #[serde(default, rename = "passwordRef")]
+    pub password_ref: Option<String>,
+    #[serde(default, rename = "sslMode")]
+    pub ssl_mode: Option<String>,
+    /// Optional list of tables (schema.table) to verify existence of.
+    #[serde(default)]
+    pub tables: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConnectionTestResponse {
+    /// `"ok"` or `"error"`.
+    pub status: String,
+    /// Round-trip latency in milliseconds; present when `status == "ok"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    /// Error description; present when `status == "error"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Tables from the request that were not found in the database.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub missing_tables: Vec<String>,
+}

--- a/crates/astra-connectors/src/lib.rs
+++ b/crates/astra-connectors/src/lib.rs
@@ -2,10 +2,10 @@ pub mod postgres;
 pub mod postgres_destination;
 
 pub use postgres::{
-    ColumnSchema, DiscoverReport, PostgresCdcSettings, PostgresConnectionConfig,
-    PostgresDiscoverOptions, PostgresSnapshotPlan, PostgresSource, PostgresSourceConfig,
-    SnapshotExecutionOptions, SnapshotExecutionReport, SnapshotTableChunk, SnapshotTableProgress,
-    SourceCatalog, SourceTable,
+    test_postgres_connection, ColumnSchema, ConnectionTestResult, DiscoverReport,
+    PostgresCdcSettings, PostgresConnectionConfig, PostgresDiscoverOptions, PostgresSnapshotPlan,
+    PostgresSource, PostgresSourceConfig, SnapshotExecutionOptions, SnapshotExecutionReport,
+    SnapshotTableChunk, SnapshotTableProgress, SourceCatalog, SourceTable,
 };
 pub use postgres_destination::{
     PostgresDestinationConfig, PostgresDestinationLoader, RawLoadChunkResult, RawLoadReport,

--- a/crates/astra-connectors/src/postgres.rs
+++ b/crates/astra-connectors/src/postgres.rs
@@ -194,6 +194,14 @@ impl PostgresSource {
         }
     }
 
+    /// Test connectivity to this Postgres source.
+    ///
+    /// Runs `SELECT 1` to measure round-trip latency and verifies that every
+    /// table in the spec exists in `information_schema.tables`.
+    pub async fn test_connection(&self) -> ConnectionTestResult {
+        test_postgres_connection(&self.config.connection, &self.config.tables).await
+    }
+
     pub async fn discover(
         &self,
         options: PostgresDiscoverOptions,
@@ -364,6 +372,100 @@ impl PostgresSource {
             table_progress,
         })
     }
+}
+
+/// Result of a Postgres connection test.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionTestResult {
+    /// `"ok"` or `"error"`.
+    pub status: String,
+    /// Round-trip latency for `SELECT 1`; present when `status == "ok"`.
+    pub latency_ms: Option<u64>,
+    /// Human-readable error description; present when `status == "error"`.
+    pub message: Option<String>,
+    /// Tables that were not found in the database (subset of the tables checked).
+    #[serde(default)]
+    pub missing_tables: Vec<String>,
+}
+
+impl ConnectionTestResult {
+    fn success(latency_ms: u64, missing_tables: Vec<String>) -> Self {
+        if missing_tables.is_empty() {
+            Self {
+                status: "ok".to_string(),
+                latency_ms: Some(latency_ms),
+                message: None,
+                missing_tables: vec![],
+            }
+        } else {
+            Self {
+                status: "error".to_string(),
+                latency_ms: Some(latency_ms),
+                message: Some(format!("tables not found: {}", missing_tables.join(", "))),
+                missing_tables,
+            }
+        }
+    }
+
+    fn failure(message: impl Into<String>) -> Self {
+        Self {
+            status: "error".to_string(),
+            latency_ms: None,
+            message: Some(message.into()),
+            missing_tables: vec![],
+        }
+    }
+}
+
+/// Test connectivity to a Postgres instance.
+///
+/// Connects, runs `SELECT 1` to measure latency, and — when `tables` is
+/// non-empty — verifies each table exists in `information_schema.tables`.
+pub async fn test_postgres_connection(
+    config: &PostgresConnectionConfig,
+    tables: &[String],
+) -> ConnectionTestResult {
+    let start = std::time::Instant::now();
+    let client = match connect(config).await {
+        Ok(c) => c,
+        Err(e) => return ConnectionTestResult::failure(format!("{:#}", e)),
+    };
+
+    if let Err(e) = client.query_one("SELECT 1", &[]).await {
+        return ConnectionTestResult::failure(format!("ping query failed: {e}"));
+    }
+    let latency_ms = start.elapsed().as_millis() as u64;
+
+    if tables.is_empty() {
+        return ConnectionTestResult::success(latency_ms, vec![]);
+    }
+
+    let mut missing = Vec::new();
+    for table in tables {
+        let (schema, name) = match split_table_name(table) {
+            Ok(pair) => pair,
+            Err(_) => {
+                missing.push(table.clone());
+                continue;
+            }
+        };
+        let rows = match client
+            .query(
+                "SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = $1 AND table_name = $2",
+                &[&schema, &name],
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return ConnectionTestResult::failure(format!("table check failed: {e}")),
+        };
+        if rows.is_empty() {
+            missing.push(table.clone());
+        }
+    }
+
+    ConnectionTestResult::success(latency_ms, missing)
 }
 
 fn parse_connection(

--- a/crates/astra-connectors/src/postgres_destination.rs
+++ b/crates/astra-connectors/src/postgres_destination.rs
@@ -1,3 +1,4 @@
+use crate::postgres::{test_postgres_connection, ConnectionTestResult, PostgresConnectionConfig};
 use anyhow::{anyhow, bail, Context};
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
@@ -79,6 +80,22 @@ impl PostgresDestinationLoader {
 
     pub fn config(&self) -> &PostgresDestinationConfig {
         &self.config
+    }
+
+    /// Test connectivity to this Postgres destination.
+    ///
+    /// Runs `SELECT 1` and reports round-trip latency.
+    pub async fn test_connection(&self) -> ConnectionTestResult {
+        let cfg = PostgresConnectionConfig {
+            host: self.config.host.clone(),
+            port: self.config.port,
+            database: self.config.database.clone(),
+            username: self.config.username.clone(),
+            password_ref: self.config.password_ref.clone(),
+            ssl_mode: self.config.ssl_mode.clone(),
+            application_name: self.config.application_name.clone(),
+        };
+        test_postgres_connection(&cfg, &[]).await
     }
 
     pub async fn load_local_stage_chunks(

--- a/website/docs/cli/reference.md
+++ b/website/docs/cli/reference.md
@@ -72,6 +72,44 @@ Output includes table names, column names, data types, nullability, and primary 
 
 ---
 
+### `test-connection`
+
+Test connectivity for the source or destination in an Astra YAML spec.
+
+```bash
+cargo run -p astra -- test-connection <spec-file> [--target source|destination]
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--target <TARGET>` | Which side to test: `source` or `destination` (default: `source`). |
+
+**Example:**
+
+```bash
+POSTGRES_PASSWORD=secret \
+  cargo run -p astra -- test-connection my-pipeline.astra.yaml --target source
+# status: ok
+# latency_ms: 4
+```
+
+**What it does:**
+
+- Establishes a connection to the target database and runs `SELECT 1` to measure round-trip latency.
+- For the `source` target, also verifies that every table in `capture.tables` exists in `information_schema.tables`.
+- Exits with code 0 on success, non-zero if the connection fails or any configured table is missing.
+
+**Failure output:**
+
+```
+status: error
+message: failed to connect to Postgres source at db.example.com:5432: connection refused
+```
+
+---
+
 ### `snapshot-to-local-staging`
 
 Run the capture phase: paginate through source tables and write compressed JSONL.gz chunks to a local directory.

--- a/website/docs/control-plane/api.md
+++ b/website/docs/control-plane/api.md
@@ -234,6 +234,54 @@ Delete a saved connection by name. Returns `204 No Content`, or `404` if not fou
 
 > **Note:** Deleting a saved connection does not affect pipelines that were already applied — `connectionRef` is resolved and inlined at apply time, so existing pipeline specs are unaffected.
 
+### `POST /api/v1/connections/test`
+
+Test connectivity to a database without creating a saved connection. Returns a structured pass/fail result with round-trip latency. Optionally verifies that specific tables exist.
+
+**Body:**
+
+```json
+{
+  "kind": "postgres",
+  "host": "db.example.com",
+  "port": 5432,
+  "database": "app",
+  "username": "replicator",
+  "passwordRef": "env:POSTGRES_PASSWORD",
+  "tables": ["public.users", "public.orders"]
+}
+```
+
+`passwordRef` and `sslMode` are optional. `tables` is optional — when supplied, the endpoint verifies each table exists in `information_schema.tables`.
+
+**Response (success):**
+
+```json
+{ "status": "ok", "latency_ms": 4 }
+```
+
+**Response (connection failure):**
+
+```json
+{
+  "status": "error",
+  "message": "failed to connect to Postgres source at db.example.com:5432: connection refused"
+}
+```
+
+**Response (missing tables):**
+
+```json
+{
+  "status": "error",
+  "latency_ms": 3,
+  "message": "tables not found: public.missing_table",
+  "missing_tables": ["public.missing_table"]
+}
+```
+
+Currently only `"postgres"` is supported for `kind`. Other values return `400 Bad Request`.
+
 ---
 
 ## Spec apply


### PR DESCRIPTION
## Summary

Closes #100

- **`astra test-connection <spec.yaml> [--target source|destination]`** — validates source or destination connectivity before running a pipeline. Connects to Postgres, runs `SELECT 1` to measure round-trip latency, and verifies every table in `capture.tables` exists in `information_schema.tables`. Exits non-zero on failure.
- **`POST /api/v1/connections/test`** — accepts inline connection config (host, port, database, username, optional `passwordRef`/`sslMode`, optional `tables` list) and returns a machine-readable `{ "status": "ok", "latency_ms": N }` or `{ "status": "error", "message": "..." }` with an optional `missing_tables` list.
- **`ConnectionTestResult`** type added to `astra-connectors`, exported from the crate root, and shared by both the CLI and HTTP handler.
- `PostgresSource::test_connection` and `PostgresDestinationLoader::test_connection` methods delegate to the shared `test_postgres_connection` function.
- Two new parse tests added to the CLI test suite for `test-connection` with default and explicit `--target` values.

## Test plan

- [x] `cargo build --workspace` — clean build, zero warnings
- [x] `cargo test --workspace` — 28 tests pass (pg-persistence integration tests require Docker and were already failing before this change)
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --all` — enforced by pre-commit hook
- [ ] Manual: `astra test-connection <spec.yaml>` against a reachable Postgres returns `status: ok` with a latency
- [ ] Manual: `astra test-connection <spec.yaml>` against an unreachable host returns `status: error` and exits 1
- [ ] Manual: `POST /api/v1/connections/test` with a valid config returns `{ "status": "ok", "latency_ms": N }`
- [ ] Manual: `POST /api/v1/connections/test` with an unknown kind returns `400 Bad Request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)