### PR TITLE
feat(http): HTTP handler tests and 404 fix for connections CRUD

### DIFF
--- a/apps/control-plane/Cargo.toml
+++ b/apps/control-plane/Cargo.toml
@@ -46,3 +46,4 @@ testcontainers = "0.17"
 testcontainers-modules = { version = "0.5", features = ["postgres"] }
 tokio-postgres = { version = "0.7", default-features = false, features = ["runtime", "with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 serde_yaml.workspace = true
+tower = { version = "0.4", features = ["util"] }

--- a/apps/control-plane/src/http/connections.rs
+++ b/apps/control-plane/src/http/connections.rs
@@ -101,6 +101,11 @@ pub async fn delete_connection(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, AppError> {
+    state
+        .connection_service
+        .get_connection(&name)
+        .await?
+        .ok_or_else(|| NotFoundError(name.clone()))?;
     state.connection_service.delete_connection(&name).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -133,4 +138,293 @@ pub async fn test_connection(
         message: result.message,
         missing_tables: result.missing_tables,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        authz::AstraEnforcer,
+        repositories::{InMemoryConnectionRepository, InMemoryPipelineRepository},
+        services::{ConnectionService, PipelineService},
+        state::AppState,
+    };
+    use axum::{
+        body::Body,
+        http::{self, Request},
+        routing::get,
+        Router,
+    };
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    async fn test_app() -> Router {
+        let conn_repo = Arc::new(InMemoryConnectionRepository::default());
+        let connection_service = Arc::new(ConnectionService::new(conn_repo));
+        let pipeline_repo = Arc::new(InMemoryPipelineRepository::default());
+        let pipeline_service = Arc::new(PipelineService::new(
+            pipeline_repo,
+            connection_service.clone(),
+        ));
+        let enforcer = Arc::new(AstraEnforcer::new_memory().await.unwrap());
+        let state = AppState::new(pipeline_service, connection_service, None, enforcer);
+
+        Router::new()
+            .route(
+                "/api/v1/connections",
+                get(list_connections).post(create_connection),
+            )
+            .route(
+                "/api/v1/connections/:name",
+                get(get_connection)
+                    .put(update_connection)
+                    .delete(delete_connection),
+            )
+            .with_state(state)
+    }
+
+    fn connection_body(name: &str) -> Body {
+        Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "name": name,
+                "kind": "postgres",
+                "host": "localhost",
+                "port": 5432,
+                "database": "testdb",
+                "username": "testuser"
+            }))
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn list_connections_returns_empty_list() {
+        let app = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri("/api/v1/connections")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["connections"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn create_connection_returns_201() {
+        let app = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/api/v1/connections")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(connection_body("my-pg"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "my-pg");
+        assert_eq!(json["kind"], "postgres");
+        assert_eq!(json["host"], "localhost");
+        assert_eq!(json["port"], 5432);
+        assert!(!json["id"].as_str().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_connection_invalid_name_returns_400() {
+        let app = test_app().await;
+        let bad_body = Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "name": "INVALID_NAME",
+                "kind": "postgres",
+                "host": "localhost",
+                "port": 5432,
+                "database": "testdb",
+                "username": "testuser"
+            }))
+            .unwrap(),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/api/v1/connections")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(bad_body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_connection_returns_200() {
+        let app = test_app().await;
+
+        // Create first
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/api/v1/connections")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(connection_body("get-test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Then get it
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri("/api/v1/connections/get-test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "get-test");
+    }
+
+    #[tokio::test]
+    async fn get_connection_not_found_returns_404() {
+        let app = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri("/api/v1/connections/no-such-conn")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn update_connection_returns_200() {
+        let app = test_app().await;
+
+        // Create first
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/api/v1/connections")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(connection_body("upd-test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Update it
+        let updated_body = Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "name": "upd-test",
+                "kind": "postgres",
+                "host": "newhost",
+                "port": 5433,
+                "database": "newdb",
+                "username": "newuser"
+            }))
+            .unwrap(),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::PUT)
+                    .uri("/api/v1/connections/upd-test")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(updated_body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["host"], "newhost");
+        assert_eq!(json["port"], 5433);
+    }
+
+    #[tokio::test]
+    async fn delete_connection_returns_204() {
+        let app = test_app().await;
+
+        // Create first
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/api/v1/connections")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(connection_body("del-test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Delete it
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::DELETE)
+                    .uri("/api/v1/connections/del-test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_connection_returns_404() {
+        let app = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::DELETE)
+                    .uri("/api/v1/connections/ghost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 8 axum handler-level unit tests covering all 5 connection REST endpoints (`GET /api/v1/connections`, `POST`, `GET /:name`, `PUT /:name`, `DELETE /:name`), including status code assertions and response body validation
- Fixes `DELETE /api/v1/connections/:name` to return **404** (not 500) when the named connection does not exist — handler now does a get-before-delete using the existing `NotFoundError` pattern
- Adds `tower` as a dev-dependency for `ServiceExt::oneshot` used in the handler tests

## Test plan

- [x] `cargo test -p astra-control-plane --lib http::connections::tests` — all 8 handler tests pass
- [x] `cargo test -p astra-control-plane --lib` — all 27 unit tests pass
- [x] `cargo clippy -p astra-control-plane` — clean, no warnings
- [x] `cargo fmt --all` — no formatting changes

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)