### PR TITLE
feat(web): auth UI — LoginPage, AuthContext, UserMenu, fetchWithAuth

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import type { ViewKey } from '@/types';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { LoginPage } from '@/components/LoginPage';
+import { UserMenu } from '@/components/UserMenu';
 import { Overview } from '@/components/Overview';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
 import { PipelineList } from '@/components/PipelineList';
@@ -14,9 +17,22 @@ const NAV_ITEMS: Array<{ key: ViewKey; label: string; eyebrow: string }> = [
   { key: 'yaml', label: 'YAML studio', eyebrow: 'Declarative workflows' },
 ];
 
-export function App() {
+function AppShell() {
+  const { user, isLoading } = useAuth();
   const [activeView, setActiveView] = useState<ViewKey>('overview');
   const [refreshToken, setRefreshToken] = useState(0);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground text-sm">
+        Loading…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <LoginPage />;
+  }
 
   function handlePipelineApplied() {
     setRefreshToken((n) => n + 1);
@@ -34,7 +50,7 @@ export function App() {
           </p>
         </div>
 
-        <nav className="flex flex-col gap-1">
+        <nav className="flex flex-col gap-1 flex-1">
           {NAV_ITEMS.map((item) => (
             <Button
               key={item.key}
@@ -47,6 +63,8 @@ export function App() {
             </Button>
           ))}
         </nav>
+
+        <UserMenu />
       </aside>
 
       {/* Main content */}
@@ -72,5 +90,13 @@ export function App() {
         {activeView === 'yaml' && <YamlStudio />}
       </main>
     </div>
+  );
+}
+
+export function App() {
+  return (
+    <AuthProvider>
+      <AppShell />
+    </AuthProvider>
   );
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,13 +1,74 @@
 import type {
   ApplySpecResponse,
+  MeResponse,
   PipelineRunsResponse,
   PipelinesResponse,
   PipelineSummaryResponse,
   TableExecutionsResponse,
 } from '@/types';
 
+// ── Auth helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Registered by AuthContext on mount. Called when a token refresh fails so the
+ * context can clear state and force the login page.
+ */
+let _onUnauthorized: (() => void) | null = null;
+export function registerUnauthorizedHandler(fn: () => void) {
+  _onUnauthorized = fn;
+}
+
+/**
+ * Wraps `fetch` with automatic token refresh on 401.
+ * Cookies are sent automatically (same-origin); no extra headers needed.
+ * On a second 401 after refresh the caller receives the failed response and
+ * the unauthorized handler is invoked to clear auth state.
+ */
+export async function fetchWithAuth(input: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(input, init);
+  if (res.status !== 401) return res;
+
+  // Attempt refresh.
+  const refreshRes = await fetch('/api/v1/auth/refresh', { method: 'POST' });
+  if (!refreshRes.ok) {
+    _onUnauthorized?.();
+    return res;
+  }
+
+  // Retry original request once.
+  const retried = await fetch(input, init);
+  if (retried.status === 401) _onUnauthorized?.();
+  return retried;
+}
+
+// ── Auth API ─────────────────────────────────────────────────────────────────
+
+export async function loginUser(email: string, password: string): Promise<void> {
+  const res = await fetch('/api/v1/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Login failed: ${res.status}`);
+  }
+}
+
+export async function logoutUser(): Promise<void> {
+  await fetch('/api/v1/auth/logout', { method: 'POST' });
+}
+
+export async function fetchMe(): Promise<MeResponse> {
+  const res = await fetchWithAuth('/api/v1/auth/me');
+  if (!res.ok) throw new Error(`Unauthenticated`);
+  return res.json() as Promise<MeResponse>;
+}
+
+// ── Pipeline API ─────────────────────────────────────────────────────────────
+
 export async function fetchPipelines(): Promise<PipelinesResponse> {
-  const res = await fetch('/api/v1/pipelines');
+  const res = await fetchWithAuth('/api/v1/pipelines');
   if (!res.ok) throw new Error(`Pipeline request failed: ${res.status}`);
   return res.json() as Promise<PipelinesResponse>;
 }
@@ -19,19 +80,23 @@ export async function fetchExampleYaml(): Promise<string> {
 }
 
 export async function fetchRunHistory(pipelineName: string): Promise<PipelineRunsResponse> {
-  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/run-history`);
+  const res = await fetchWithAuth(
+    `/api/v1/pipelines/${encodeURIComponent(pipelineName)}/run-history`,
+  );
   if (!res.ok) throw new Error(`Run history request failed: ${res.status}`);
   return res.json() as Promise<PipelineRunsResponse>;
 }
 
 export async function fetchTableExecutions(runId: string): Promise<TableExecutionsResponse> {
-  const res = await fetch(`/api/v1/pipeline-runs/${encodeURIComponent(runId)}/table-executions`);
+  const res = await fetchWithAuth(
+    `/api/v1/pipeline-runs/${encodeURIComponent(runId)}/table-executions`,
+  );
   if (!res.ok) throw new Error(`Table executions request failed: ${res.status}`);
   return res.json() as Promise<TableExecutionsResponse>;
 }
 
 export async function applySpec(yaml: string, createdBy: string): Promise<ApplySpecResponse> {
-  const res = await fetch('/api/v1/specs/apply', {
+  const res = await fetchWithAuth('/api/v1/specs/apply', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ yaml, created_by: createdBy }),
@@ -44,9 +109,10 @@ export async function applySpec(yaml: string, createdBy: string): Promise<ApplyS
 }
 
 export async function deletePipeline(pipelineName: string): Promise<void> {
-  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}`, {
-    method: 'DELETE',
-  });
+  const res = await fetchWithAuth(
+    `/api/v1/pipelines/${encodeURIComponent(pipelineName)}`,
+    { method: 'DELETE' },
+  );
   if (!res.ok) {
     const errorText = await res.text();
     throw new Error(errorText || `Delete failed with status ${res.status}`);
@@ -54,9 +120,10 @@ export async function deletePipeline(pipelineName: string): Promise<void> {
 }
 
 export async function disablePipeline(pipelineName: string): Promise<PipelineSummaryResponse> {
-  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/disable`, {
-    method: 'POST',
-  });
+  const res = await fetchWithAuth(
+    `/api/v1/pipelines/${encodeURIComponent(pipelineName)}/disable`,
+    { method: 'POST' },
+  );
   if (!res.ok) {
     const errorText = await res.text();
     throw new Error(errorText || `Disable failed with status ${res.status}`);
@@ -65,9 +132,10 @@ export async function disablePipeline(pipelineName: string): Promise<PipelineSum
 }
 
 export async function enablePipeline(pipelineName: string): Promise<PipelineSummaryResponse> {
-  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/enable`, {
-    method: 'POST',
-  });
+  const res = await fetchWithAuth(
+    `/api/v1/pipelines/${encodeURIComponent(pipelineName)}/enable`,
+    { method: 'POST' },
+  );
   if (!res.ok) {
     const errorText = await res.text();
     throw new Error(errorText || `Enable failed with status ${res.status}`);
@@ -76,9 +144,10 @@ export async function enablePipeline(pipelineName: string): Promise<PipelineSumm
 }
 
 export async function triggerPipeline(pipelineName: string): Promise<{ run_id: string }> {
-  const res = await fetch(`/api/v1/pipelines/${encodeURIComponent(pipelineName)}/trigger`, {
-    method: 'POST',
-  });
+  const res = await fetchWithAuth(
+    `/api/v1/pipelines/${encodeURIComponent(pipelineName)}/trigger`,
+    { method: 'POST' },
+  );
   if (!res.ok) {
     const errorText = await res.text();
     throw new Error(errorText || `Trigger failed with status ${res.status}`);

--- a/apps/web/src/components/LoginPage.tsx
+++ b/apps/web/src/components/LoginPage.tsx
@@ -1,0 +1,73 @@
+import { useState, type FormEvent } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login(email, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed. Check your credentials.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center">
+          <div className="text-3xl font-extrabold tracking-tight">Astra</div>
+          <p className="mt-2 text-sm text-muted-foreground">Sign in to your account</p>
+        </div>
+
+        <Card>
+          <CardContent className="pt-6">
+            <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="login-email">Email</Label>
+                <Input
+                  id="login-email"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="admin@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="login-password">Password</Label>
+                <Input
+                  id="login-password"
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              {error && <p className="text-sm text-destructive">{error}</p>}
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? 'Signing in…' : 'Sign in'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -1,0 +1,32 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+export function UserMenu() {
+  const { user, logout } = useAuth();
+  if (!user) return null;
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border pt-4">
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/20 text-xs font-bold uppercase">
+          {user.email[0]}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium">{user.email}</p>
+          <Badge variant="muted" className="mt-0.5 text-[10px] px-1.5 py-0">
+            {user.auth_source}
+          </Badge>
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start text-muted-foreground hover:text-foreground"
+        onClick={() => void logout()}
+      >
+        Sign out
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,0 +1,60 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { MeResponse } from '@/types';
+import { fetchMe, loginUser, logoutUser, registerUnauthorizedHandler } from '@/api';
+
+interface AuthContextValue {
+  user: MeResponse | null;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<MeResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const clearAuth = useCallback(() => {
+    setUser(null);
+  }, []);
+
+  // Restore session on mount by calling /api/v1/auth/me.
+  useEffect(() => {
+    registerUnauthorizedHandler(clearAuth);
+    fetchMe()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false));
+  }, [clearAuth]);
+
+  const login = useCallback(async (email: string, password: string) => {
+    await loginUser(email, password);
+    const me = await fetchMe();
+    setUser(me);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await logoutUser();
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,11 @@
 export type ViewKey = 'overview' | 'onboarding' | 'jobs' | 'yaml';
 
+export interface MeResponse {
+  id: string;
+  email: string;
+  auth_source: 'local' | 'ldap';
+}
+
 export type Pipeline = {
   name: string;
   source_kind: string;


### PR DESCRIPTION
## Summary

Adds authentication UI to the React frontend (closes #150, depends on #149).

- **`AuthContext`** (`src/contexts/AuthContext.tsx`) — `AuthProvider` wraps the app, calls `GET /api/v1/auth/me` on mount to restore session from cookie, exposes `user`, `isLoading`, `login`, and `logout`; registers the `fetchWithAuth` unauthorized handler so failed refreshes clear auth state automatically
- **`LoginPage`** (`src/components/LoginPage.tsx`) — centred email/password form, calls `login()`, shows inline error on failure
- **`UserMenu`** (`src/components/UserMenu.tsx`) — pinned to sidebar bottom; shows avatar initial, email, auth_source badge (`local`/`ldap`), and a sign-out button
- **`fetchWithAuth`** (`src/api.ts`) — wraps `fetch` with one-shot 401 → refresh → retry logic; all protected API calls now use it; `loginUser`, `logoutUser`, `fetchMe` added
- **`types.ts`** — adds `MeResponse` interface
- **`App.tsx`** — root wrapped in `<AuthProvider>`; `AppShell` renders a loading spinner while session resolves, `<LoginPage>` when unauthenticated, and the full layout (with `<UserMenu>`) when logged in

## Test plan

- [x] `npm run lint` — TypeScript type-check passes, no errors
- [ ] Manual: start control plane with `ASTRA_JWT_SECRET` set, open the app — login page is shown; enter credentials → main layout loads with user email in sidebar
- [ ] Manual: click Sign out → login page returns
- [ ] Manual: with a valid session, let the access token expire — next API call triggers a transparent refresh and succeeds

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)