### PR TITLE
feat(web): connections UI — ConnectionList, ConnectionForm, wizard integration

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import type { ViewKey } from '@/types';
 import { Overview } from '@/components/Overview';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
 import { PipelineList } from '@/components/PipelineList';
+import { ConnectionList } from '@/components/ConnectionList';
 import { YamlStudio } from '@/components/YamlStudio';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -11,6 +12,7 @@ const NAV_ITEMS: Array<{ key: ViewKey; label: string; eyebrow: string }> = [
   { key: 'overview', label: 'Overview', eyebrow: 'Control plane' },
   { key: 'onboarding', label: 'Onboarding', eyebrow: 'Source → destination' },
   { key: 'jobs', label: 'Job status', eyebrow: 'Operators' },
+  { key: 'connections', label: 'Connections', eyebrow: 'Infrastructure' },
   { key: 'yaml', label: 'YAML studio', eyebrow: 'Declarative workflows' },
 ];
 
@@ -69,6 +71,7 @@ export function App() {
         {activeView === 'overview' && <Overview />}
         {activeView === 'onboarding' && <OnboardingWizard onApplied={handlePipelineApplied} />}
         {activeView === 'jobs' && <PipelineList refreshToken={refreshToken} />}
+        {activeView === 'connections' && <ConnectionList />}
         {activeView === 'yaml' && <YamlStudio />}
       </main>
     </div>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -3,6 +3,9 @@ import type {
   PipelineRunsResponse,
   PipelinesResponse,
   PipelineSummaryResponse,
+  SavedConnectionRequest,
+  SavedConnectionResponse,
+  SavedConnectionsResponse,
   TableExecutionsResponse,
 } from '@/types';
 
@@ -84,4 +87,54 @@ export async function triggerPipeline(pipelineName: string): Promise<{ run_id: s
     throw new Error(errorText || `Trigger failed with status ${res.status}`);
   }
   return res.json() as Promise<{ run_id: string }>;
+}
+
+// ── Connections API ───────────────────────────────────────────────────────────
+
+export async function fetchConnections(): Promise<SavedConnectionResponse[]> {
+  const res = await fetch('/api/v1/connections');
+  if (!res.ok) throw new Error(`Connections request failed: ${res.status}`);
+  const data = (await res.json()) as SavedConnectionsResponse;
+  return data.connections;
+}
+
+export async function createConnection(
+  req: SavedConnectionRequest,
+): Promise<SavedConnectionResponse> {
+  const res = await fetch('/api/v1/connections', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Create connection failed: ${res.status}`);
+  }
+  return res.json() as Promise<SavedConnectionResponse>;
+}
+
+export async function updateConnection(
+  name: string,
+  req: SavedConnectionRequest,
+): Promise<SavedConnectionResponse> {
+  const res = await fetch(`/api/v1/connections/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Update connection failed: ${res.status}`);
+  }
+  return res.json() as Promise<SavedConnectionResponse>;
+}
+
+export async function deleteConnection(name: string): Promise<void> {
+  const res = await fetch(`/api/v1/connections/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Delete connection failed: ${res.status}`);
+  }
 }

--- a/apps/web/src/components/ConnectionForm.tsx
+++ b/apps/web/src/components/ConnectionForm.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import type { SavedConnectionRequest, SavedConnectionResponse } from '@/types';
+import { createConnection, updateConnection } from '@/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+
+const KINDS = ['postgres', 'mysql', 'snowflake'] as const;
+type Kind = (typeof KINDS)[number];
+
+const DEFAULT_PORTS: Record<Kind, number> = {
+  postgres: 5432,
+  mysql: 3306,
+  snowflake: 443,
+};
+
+interface Props {
+  /** When set, the form is in edit mode for this connection. */
+  editing?: SavedConnectionResponse;
+  onSaved: (conn: SavedConnectionResponse) => void;
+  onCancel: () => void;
+}
+
+export function ConnectionForm({ editing, onSaved, onCancel }: Props) {
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<Kind>('postgres');
+  const [host, setHost] = useState('');
+  const [port, setPort] = useState(5432);
+  const [database, setDatabase] = useState('');
+  const [username, setUsername] = useState('');
+  const [secretRef, setSecretRef] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Populate fields when editing an existing connection.
+  useEffect(() => {
+    if (editing) {
+      setName(editing.name);
+      setKind((editing.kind as Kind) ?? 'postgres');
+      setHost(editing.host);
+      setPort(editing.port);
+      setDatabase(editing.database);
+      setUsername(editing.username);
+      setSecretRef(editing.secret_ref ?? '');
+    }
+  }, [editing]);
+
+  // When kind changes in create mode, update the default port.
+  function handleKindChange(k: Kind) {
+    setKind(k);
+    if (!editing) setPort(DEFAULT_PORTS[k]);
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+    const req: SavedConnectionRequest = {
+      name,
+      kind,
+      host,
+      port,
+      database,
+      username,
+      ...(secretRef.trim() ? { secret_ref: secretRef.trim() } : {}),
+    };
+    try {
+      const saved = editing
+        ? await updateConnection(editing.name, req)
+        : await createConnection(req);
+      onSaved(saved);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+      <Card className="w-full max-w-lg">
+        <CardContent className="pt-6 space-y-4">
+          <div>
+            <h2 className="text-base font-semibold">
+              {editing ? 'Edit connection' : 'New connection'}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Saved connections can be referenced by name in pipeline specs.
+            </p>
+          </div>
+
+          <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+            {/* Name */}
+            <div className="space-y-2">
+              <Label htmlFor="cf-name">Name</Label>
+              <Input
+                id="cf-name"
+                placeholder="my-postgres"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={!!editing}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Lowercase letters, digits, and hyphens only (e.g. <code>prod-db</code>).
+              </p>
+            </div>
+
+            {/* Kind */}
+            <div className="space-y-2">
+              <Label>Kind</Label>
+              <div className="flex gap-2">
+                {KINDS.map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => handleKindChange(k)}
+                    className={[
+                      'px-3 py-1.5 rounded-md text-xs font-medium border transition-colors',
+                      kind === k
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'bg-background text-muted-foreground border-border hover:border-foreground/40',
+                    ].join(' ')}
+                  >
+                    {k}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Host + Port */}
+            <div className="grid grid-cols-[1fr_7rem] gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="cf-host">Host</Label>
+                <Input
+                  id="cf-host"
+                  placeholder="localhost"
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cf-port">Port</Label>
+                <Input
+                  id="cf-port"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={port}
+                  onChange={(e) => setPort(Number(e.target.value))}
+                  required
+                />
+              </div>
+            </div>
+
+            {/* Database */}
+            <div className="space-y-2">
+              <Label htmlFor="cf-database">Database</Label>
+              <Input
+                id="cf-database"
+                placeholder="app"
+                value={database}
+                onChange={(e) => setDatabase(e.target.value)}
+                required
+              />
+            </div>
+
+            {/* Username + Secret Ref */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="cf-username">Username</Label>
+                <Input
+                  id="cf-username"
+                  placeholder="app_user"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cf-secret">Secret ref</Label>
+                <Input
+                  id="cf-secret"
+                  placeholder="MY_DB_PASSWORD"
+                  value={secretRef}
+                  onChange={(e) => setSecretRef(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? 'Saving…' : editing ? 'Update' : 'Create'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/ConnectionList.tsx
+++ b/apps/web/src/components/ConnectionList.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import type { SavedConnectionResponse } from '@/types';
+import { fetchConnections, deleteConnection } from '@/api';
+import { ConnectionForm } from '@/components/ConnectionForm';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+
+export function ConnectionList() {
+  const [connections, setConnections] = useState<SavedConnectionResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showForm, setShowForm] = useState(false);
+  const [editTarget, setEditTarget] = useState<SavedConnectionResponse | undefined>();
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    try {
+      setConnections(await fetchConnections());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load connections.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function handleDelete(name: string) {
+    if (!confirm(`Delete connection "${name}"? This cannot be undone.`)) return;
+    try {
+      await deleteConnection(name);
+      setConnections((prev) => prev.filter((c) => c.name !== name));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+    }
+  }
+
+  function openCreate() {
+    setEditTarget(undefined);
+    setShowForm(true);
+  }
+
+  function openEdit(conn: SavedConnectionResponse) {
+    setEditTarget(conn);
+    setShowForm(true);
+  }
+
+  function handleSaved(conn: SavedConnectionResponse) {
+    setConnections((prev) => {
+      const idx = prev.findIndex((c) => c.name === conn.name);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = conn;
+        return next;
+      }
+      return [...prev, conn];
+    });
+    setShowForm(false);
+    setEditTarget(undefined);
+  }
+
+  return (
+    <>
+      {showForm && (
+        <ConnectionForm
+          editing={editTarget}
+          onSaved={handleSaved}
+          onCancel={() => {
+            setShowForm(false);
+            setEditTarget(undefined);
+          }}
+        />
+      )}
+
+      <Card>
+        <CardContent className="pt-5 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-muted-foreground">
+                Infrastructure
+              </p>
+              <h2 className="text-lg font-semibold mt-1">Saved connections</h2>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                Reusable connection configs referenced by name in pipeline specs.
+              </p>
+            </div>
+            <Button onClick={openCreate} className="shrink-0">
+              New connection
+            </Button>
+          </div>
+
+          {loading && (
+            <p className="text-sm text-muted-foreground">Loading connections…</p>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          {!loading && connections.length === 0 && !error && (
+            <p className="text-sm text-muted-foreground">
+              No connections yet. Click <strong>New connection</strong> to add one.
+            </p>
+          )}
+
+          {connections.length > 0 && (
+            <div className="overflow-x-auto rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
+                    <th className="px-4 py-2 text-left font-medium">Name</th>
+                    <th className="px-4 py-2 text-left font-medium">Kind</th>
+                    <th className="px-4 py-2 text-left font-medium">Host</th>
+                    <th className="px-4 py-2 text-left font-medium">Database</th>
+                    <th className="px-4 py-2 text-left font-medium">Username</th>
+                    <th className="px-4 py-2 text-left font-medium">Secret ref</th>
+                    <th className="px-4 py-2 text-right font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {connections.map((conn) => (
+                    <tr
+                      key={conn.name}
+                      className="border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="px-4 py-3 font-mono text-xs">{conn.name}</td>
+                      <td className="px-4 py-3">
+                        <Badge variant="outline">{conn.kind}</Badge>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {conn.host}:{conn.port}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">{conn.database}</td>
+                      <td className="px-4 py-3 text-muted-foreground">{conn.username}</td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {conn.secret_ref ? (
+                          <code className="text-xs">{conn.secret_ref}</code>
+                        ) : (
+                          <span className="text-muted-foreground/50">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openEdit(conn)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            onClick={() => void handleDelete(conn.name)}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/apps/web/src/components/OnboardingWizard.tsx
+++ b/apps/web/src/components/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import type { SnapshotMode, WizardState, WizardStep } from '@/types';
-import { applySpec } from '@/api';
+import { useEffect, useState } from 'react';
+import type { SavedConnectionResponse, SnapshotMode, WizardState, WizardStep } from '@/types';
+import { applySpec, fetchConnections } from '@/api';
 import { generateWizardYaml } from '@/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,6 +24,8 @@ const DEFAULT_WIZARD: WizardState = {
     username: '',
     passwordRef: 'POSTGRES_PASSWORD',
     tables: 'public.users',
+    useSavedConnection: false,
+    connectionRef: '',
   },
   destination: {
     host: 'localhost',
@@ -31,6 +33,8 @@ const DEFAULT_WIZARD: WizardState = {
     database: '',
     username: '',
     passwordRef: 'DEST_POSTGRES_PASSWORD',
+    useSavedConnection: false,
+    connectionRef: '',
   },
   applyStatus: '',
   applying: false,
@@ -47,6 +51,13 @@ type Props = { onApplied: () => void };
 
 export function OnboardingWizard({ onApplied }: Props) {
   const [wizard, setWizard] = useState<WizardState>(DEFAULT_WIZARD);
+  const [savedConnections, setSavedConnections] = useState<SavedConnectionResponse[]>([]);
+
+  useEffect(() => {
+    fetchConnections()
+      .then(setSavedConnections)
+      .catch(() => {/* silently ignore — saved connections are optional */});
+  }, []);
 
   function setStep(step: WizardStep) {
     setWizard((prev) => ({ ...prev, step }));
@@ -166,6 +177,64 @@ export function OnboardingWizard({ onApplied }: Props) {
                 Connection details for the database you want to replicate from.
               </p>
             </div>
+
+            {/* Saved-connection toggle */}
+            {savedConnections.length > 0 && (
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={wizard.source.useSavedConnection}
+                  onClick={() =>
+                    setWizard((prev) => ({
+                      ...prev,
+                      source: {
+                        ...prev.source,
+                        useSavedConnection: !prev.source.useSavedConnection,
+                        connectionRef: '',
+                      },
+                    }))
+                  }
+                  className={[
+                    'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+                    wizard.source.useSavedConnection ? 'bg-primary' : 'bg-muted',
+                  ].join(' ')}
+                >
+                  <span
+                    className={[
+                      'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform',
+                      wizard.source.useSavedConnection ? 'translate-x-4' : 'translate-x-0',
+                    ].join(' ')}
+                  />
+                </button>
+                <Label className="cursor-pointer select-none">Use saved connection</Label>
+              </div>
+            )}
+
+            {wizard.source.useSavedConnection ? (
+              <div className="space-y-2">
+                <Label htmlFor="wz-src-ref">Saved connection</Label>
+                <select
+                  id="wz-src-ref"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={wizard.source.connectionRef}
+                  onChange={(e) =>
+                    setWizard((prev) => ({
+                      ...prev,
+                      source: { ...prev.source, connectionRef: e.target.value },
+                    }))
+                  }
+                >
+                  <option value="">— select a connection —</option>
+                  {savedConnections.map((c) => (
+                    <option key={c.name} value={c.name}>
+                      {c.name} ({c.host}:{c.port}/{c.database})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <>
             <div className="grid grid-cols-[1fr_7rem] gap-3">
               <div className="space-y-2">
                 <Label htmlFor="wz-src-host">Host</Label>
@@ -222,6 +291,8 @@ export function OnboardingWizard({ onApplied }: Props) {
                 />
               </div>
             </div>
+              </>
+            )}
             <div className="space-y-2">
               <Label htmlFor="wz-src-tables">Tables to replicate</Label>
               <p className="text-xs text-muted-foreground">
@@ -288,10 +359,12 @@ export function OnboardingWizard({ onApplied }: Props) {
               </Button>
               <Button
                 disabled={
-                  !wizard.source.host.trim() ||
-                  !wizard.source.database.trim() ||
-                  !wizard.source.username.trim() ||
                   !wizard.source.tables.trim() ||
+                  (wizard.source.useSavedConnection
+                    ? !wizard.source.connectionRef
+                    : !wizard.source.host.trim() ||
+                      !wizard.source.database.trim() ||
+                      !wizard.source.username.trim()) ||
                   (wizard.snapshot.mode === 'incremental' && !wizard.snapshot.cursorField.trim())
                 }
                 onClick={() => setStep(3)}
@@ -312,6 +385,64 @@ export function OnboardingWizard({ onApplied }: Props) {
                 <code className="font-mono">astra_raw</code> schema.
               </p>
             </div>
+
+            {/* Saved-connection toggle */}
+            {savedConnections.length > 0 && (
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={wizard.destination.useSavedConnection}
+                  onClick={() =>
+                    setWizard((prev) => ({
+                      ...prev,
+                      destination: {
+                        ...prev.destination,
+                        useSavedConnection: !prev.destination.useSavedConnection,
+                        connectionRef: '',
+                      },
+                    }))
+                  }
+                  className={[
+                    'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+                    wizard.destination.useSavedConnection ? 'bg-primary' : 'bg-muted',
+                  ].join(' ')}
+                >
+                  <span
+                    className={[
+                      'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform',
+                      wizard.destination.useSavedConnection ? 'translate-x-4' : 'translate-x-0',
+                    ].join(' ')}
+                  />
+                </button>
+                <Label className="cursor-pointer select-none">Use saved connection</Label>
+              </div>
+            )}
+
+            {wizard.destination.useSavedConnection ? (
+              <div className="space-y-2">
+                <Label htmlFor="wz-dst-ref">Saved connection</Label>
+                <select
+                  id="wz-dst-ref"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={wizard.destination.connectionRef}
+                  onChange={(e) =>
+                    setWizard((prev) => ({
+                      ...prev,
+                      destination: { ...prev.destination, connectionRef: e.target.value },
+                    }))
+                  }
+                >
+                  <option value="">— select a connection —</option>
+                  {savedConnections.map((c) => (
+                    <option key={c.name} value={c.name}>
+                      {c.name} ({c.host}:{c.port}/{c.database})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <>
             <div className="grid grid-cols-[1fr_7rem] gap-3">
               <div className="space-y-2">
                 <Label htmlFor="wz-dst-host">Host</Label>
@@ -375,15 +506,19 @@ export function OnboardingWizard({ onApplied }: Props) {
                 />
               </div>
             </div>
+              </>
+            )}
             <div className="flex justify-between">
               <Button variant="outline" onClick={() => setStep(2)}>
                 ← Back
               </Button>
               <Button
                 disabled={
-                  !wizard.destination.host.trim() ||
-                  !wizard.destination.database.trim() ||
-                  !wizard.destination.username.trim()
+                  wizard.destination.useSavedConnection
+                    ? !wizard.destination.connectionRef
+                    : !wizard.destination.host.trim() ||
+                      !wizard.destination.database.trim() ||
+                      !wizard.destination.username.trim()
                 }
                 onClick={() => setStep(4)}
               >

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,4 +1,4 @@
-export type ViewKey = 'overview' | 'onboarding' | 'jobs' | 'yaml';
+export type ViewKey = 'overview' | 'onboarding' | 'jobs' | 'yaml' | 'connections';
 
 export type Pipeline = {
   name: string;
@@ -84,6 +84,8 @@ export type WizardSource = {
   username: string;
   passwordRef: string;
   tables: string;
+  useSavedConnection: boolean;
+  connectionRef: string;
 };
 
 export type WizardDestination = {
@@ -92,7 +94,39 @@ export type WizardDestination = {
   database: string;
   username: string;
   passwordRef: string;
+  useSavedConnection: boolean;
+  connectionRef: string;
 };
+
+// ── Saved Connections ─────────────────────────────────────────────────────────
+
+export interface SavedConnectionRequest {
+  name: string;
+  kind: string;
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  secret_ref?: string;
+}
+
+export interface SavedConnectionResponse {
+  id: string;
+  name: string;
+  kind: string;
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  secret_ref: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SavedConnectionsResponse {
+  connections: SavedConnectionResponse[];
+}
 
 export type WizardState = {
   step: WizardStep;

--- a/apps/web/src/utils.ts
+++ b/apps/web/src/utils.ts
@@ -72,6 +72,26 @@ export function generateWizardYaml(w: WizardState): string {
     snapshotBlock = `    snapshot:\n${lines.join('\n')}\n`;
   }
 
+  const sourceConn =
+    w.source.useSavedConnection && w.source.connectionRef
+      ? `  connectionRef: ${yamlQuote(w.source.connectionRef)}`
+      : `  connection:
+    host: ${yamlQuote(w.source.host)}
+    port: ${w.source.port}
+    database: ${yamlQuote(w.source.database)}
+    username: ${yamlQuote(w.source.username)}
+    passwordRef: env:${w.source.passwordRef}`;
+
+  const destConn =
+    w.destination.useSavedConnection && w.destination.connectionRef
+      ? `  connectionRef: ${yamlQuote(w.destination.connectionRef)}`
+      : `  connection:
+    host: ${yamlQuote(w.destination.host)}
+    port: ${w.destination.port}
+    database: ${yamlQuote(w.destination.database)}
+    username: ${yamlQuote(w.destination.username)}
+    passwordRef: env:${w.destination.passwordRef}`;
+
   return `version: v1alpha1
 pipeline:
   name: ${yamlQuote(pipelineName)}
@@ -79,23 +99,13 @@ pipeline:
   schedule: manual
 source:
   kind: postgres
-  connection:
-    host: ${yamlQuote(w.source.host)}
-    port: ${w.source.port}
-    database: ${yamlQuote(w.source.database)}
-    username: ${yamlQuote(w.source.username)}
-    passwordRef: env:${w.source.passwordRef}
+${sourceConn}
   capture:
     tables:
 ${tableLines}
 ${snapshotBlock}destination:
   kind: postgres
-  connection:
-    host: ${yamlQuote(w.destination.host)}
-    port: ${w.destination.port}
-    database: ${yamlQuote(w.destination.database)}
-    username: ${yamlQuote(w.destination.username)}
-    passwordRef: env:${w.destination.passwordRef}
+${destConn}
   staging:
     kind: local
     bucket: astra-staging


### PR DESCRIPTION
## Summary

Adds a Connections management UI and integrates saved connections into the pipeline onboarding wizard (closes #156, depends on #155).

- **`ConnectionList`** (`src/components/ConnectionList.tsx`) — table of saved connections (name, kind, host:port, database, username, secret ref) with per-row Edit and Delete buttons; "New connection" button opens `ConnectionForm`
- **`ConnectionForm`** (`src/components/ConnectionForm.tsx`) — modal form for create and edit; kind selector (postgres / mysql / snowflake) auto-fills the default port; used for both `POST /api/v1/connections` and `PUT /api/v1/connections/:name`
- **`App.tsx`** — adds `'connections'` to `ViewKey`, inserts a "Connections / Infrastructure" nav item, renders `<ConnectionList>` when active
- **`api.ts`** — adds `fetchConnections`, `createConnection`, `updateConnection`, `deleteConnection`
- **`types.ts`** — adds `SavedConnectionRequest`, `SavedConnectionResponse`, `SavedConnectionsResponse`; extends `WizardSource` and `WizardDestination` with `useSavedConnection` and `connectionRef`
- **`OnboardingWizard`** — Steps 2 and 3 load saved connections on mount; when any exist a toggle appears; toggling on shows a dropdown that sets `connectionRef` and hides manual fields; Next button respects both modes
- **`utils.ts`** — `generateWizardYaml` emits `connectionRef: <name>` instead of the inline `connection:` block when a saved connection is selected

## Test plan

- [x] `npm run lint` — TypeScript type-check passes, no errors
- [ ] Manual: navigate to Connections tab → table loads; create, edit, and delete a connection
- [ ] Manual: open Onboarding → go to Source step; with a saved connection present the toggle appears; select one → review YAML shows `connectionRef` instead of inline fields
- [ ] Manual: without any saved connections the toggle is hidden and the form behaves as before

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)